### PR TITLE
Support binary content in HttpAPI

### DIFF
--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -22,7 +22,7 @@ api.get("/todo/{id}", {}, async (req, res) => {
 api.post("/todo/{id}", {}, async (req, res) => {
     console.log("POST /todo/" + req.params.id);
     try {
-        await todos.insert({ id: req.params.id, value: req.body });
+        await todos.insert({ id: req.params.id, value: req.body.toString() });
         res.status(201).json({});
     } catch (err) {
         res.status(500).json(err);


### PR DESCRIPTION
Fixes #21.  Enables binary data to be served from `routeStatic` as well as passing through
raw binary data on both requests and response body payloads for function handlers.

API Gateway supports this only via transformation to the binary input to base64 and back. As
a result, we tell API Gateway to treat all inputs as binary, and then base64 decode them into the
Buffer we pass to users as the request body.  Similarly, we collect the response buffer, then base64
encode it to hand back to API Gateway, which will transform back into binary.

It's a little crazy that we have to do all this encoding/decoding, but API Gateway does not appear
to support binary content  lambda integrations without this.