### PR TITLE
Support for middleware in HttpAPI

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -56,42 +56,43 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/pulumi",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, checkpoint environment.Checkpoint) {
-				var baseUrl string
+				var baseURL string
 				for _, kv := range checkpoint.Latest.Resources.Iter() {
 					urn := kv.Key
 					res := kv.Value
 					if res.Type == "aws:apigateway/deployment:Deployment" && strings.HasPrefix(string(urn.Name()), "todo") {
-						baseUrl = res.Outputs["invokeUrl"].(string) + "stage/"
+						baseURL = res.Outputs["invokeUrl"].(string) + "stage/"
 
 					}
 				}
-				assert.NotNil(t, baseUrl, "expected to find a RestAPI Deployment with an `invokeURL`")
+				assert.NotNil(t, baseURL, "expected to find a RestAPI Deployment with an `invokeURL`")
 
 				// Validate the GET / endpoint
-				resp, err := http.Get(baseUrl)
+				resp, err := http.Get(baseURL)
 				assert.NoError(t, err, "expected to be able to GET /")
 				contentType := resp.Header.Get("Content-Type")
 				assert.Equal(t, "text/html", contentType)
 
 				// Validate the GET /favico.ico endpoint
-				resp, err = http.Get(baseUrl + "/favicon.ico")
+				resp, err = http.Get(baseURL + "/favicon.ico")
 				assert.NoError(t, err, "expected to be able to GET /favicon.ico")
 				assert.Equal(t, int64(1150), resp.ContentLength)
 
 				// Validate the POST /todo/{id} endpoint
-				resp, err = http.Post(baseUrl+"/todo/abc", "application/x-www-form-urlencoded", strings.NewReader("xyz"))
+				resp, err = http.Post(baseURL+"/todo/abc", "application/x-www-form-urlencoded", strings.NewReader("xyz"))
 				assert.NoError(t, err, "expected to be able to POST /todo/{id}")
 				assert.Equal(t, 201, resp.StatusCode)
 
 				// Validate the GET /todo/{id} endpoint
-				resp, err = http.Get(baseUrl + "/todo/abc")
+				resp, err = http.Get(baseURL + "/todo/abc")
 				assert.NoError(t, err, "expected to be able to GET /todo/{id}")
 				byts, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(t, err)
-				assert.Equal(t, `"xyz"`, string(byts))
+				assert.Equal(t, 401, resp.StatusCode)
+				assert.Equal(t, "Authorization header required", string(byts))
 
 				// Validate the GET /todo endpoint
-				resp, err = http.Get(baseUrl + "/todo/")
+				resp, err = http.Get(baseURL + "/todo/")
 				assert.NoError(t, err, "expected to be able to GET /todo")
 				assert.Equal(t, int64(28), resp.ContentLength)
 			},

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -1,16 +1,17 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
+import {authMiddleware} from "./middleware";
 
 let todos = new pulumi.Table("todo", "id", "S", {});
 let api = new pulumi.HttpAPI("todo");
 
 // Index handler
-api.routeStatic("GET", "/", "index.html", "text/html");
-api.routeStatic("GET", "/favicon.ico", "favicon.ico", "image/x-icon");
+api.staticFile("/", "index.html", "text/html");
+api.staticFile("/favicon.ico", "favicon.ico", "image/x-icon");
 
 // GET/POST todo handlers
-api.get("/todo/{id}", {}, async (req, res) => {
+api.get("/todo/{id}", [authMiddleware], async (req, res) => {
     console.log("GET /todo/" + req.params.id);
     try {
         let item = await todos.get({ id: req.params.id });
@@ -19,7 +20,7 @@ api.get("/todo/{id}", {}, async (req, res) => {
         res.status(500).json(err);
     }
 });
-api.post("/todo/{id}", {}, async (req, res) => {
+api.post("/todo/{id}", [], async (req, res) => {
     console.log("POST /todo/" + req.params.id);
     try {
         await todos.insert({ id: req.params.id, value: req.body.toString() });
@@ -28,7 +29,7 @@ api.post("/todo/{id}", {}, async (req, res) => {
         res.status(500).json(err);
     }
 });
-api.get("/todo", {}, async (req, res) => {
+api.get("/todo", [], async (req, res) => {
     console.log("GET /todo");
     try {
         let items = await todos.scan();

--- a/examples/todo/middleware.ts
+++ b/examples/todo/middleware.ts
@@ -1,0 +1,12 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export let authMiddleware: pulumi.RouteHandler = (req, res, next) => {
+    let auth = req.headers["Authorization"];
+    if (auth !== "Bearer SECRETPASSWORD") {
+        res.status(401).end("Authorization header required");
+        return;
+    }
+    next();
+};


### PR DESCRIPTION
Adds the ability to use Connect-style middleware to individual routes.

Applications of middleware shared across routes is still pending discussion in #4.

Fixes #22.

Also renames routeStatic to staticFile and removes it's method parameter.  Related to #20.