### PR TITLE
Remove duplication between type signature and lambda signature.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -293,7 +293,7 @@ interface ReqRes {
 
 type Callback = (err: any, result: APIGatewayResponse) => void;
 
-let apiGatewayToReqRes: (ev: APIGatewayRequest, body: any, cb: Callback) => ReqRes = (ev, body, cb) => {
+let apiGatewayToReqRes = (ev: APIGatewayRequest, body: any, cb: Callback): ReqRes => {
     let response = {
         statusCode: 200,
         headers: <{[header: string]: string}>{},
@@ -470,7 +470,7 @@ export class HttpAPI {
         let lambda = new LoggedFunction(
             this.apiName + sha1hash(method + ":" + path),
             [ aws.iam.AWSLambdaFullAccess ],
-            (ev: APIGatewayRequest, ctx: any, cb) => {
+            (ev: APIGatewayRequest, ctx, cb) => {
                 let body: any;
                 if (ev.body !== null) {
                     if (ev.isBase64Encoded) {


### PR DESCRIPTION
This is my personal preference for creating typed function variables.  It's a bit shorter, and i find it easier to grok as there is only one signature to look at.  If the existing syntax is preferred, I'm fine with sticking with it.