### PR TITLE
Fix `make` to build everything but not run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
+ECHO=echo -e
+
+.PHONY: default
+default: all
 
 .PHONY: all
 all: api aws examples mock test
 
 .PHONY: api
 api:
-	$(MAKE) -C ./api all
+	$(MAKE) -C ./api $(MAKECMDGOALS)
 
 .PHONY: aws
 aws:
-	$(MAKE) -C ./aws all
+	$(MAKE) -C ./aws $(MAKECMDGOALS)
 
 .PHONY: examples
 examples:
@@ -17,16 +23,16 @@ examples:
 
 .PHONY: mock
 mock:
-	$(MAKE) -C ./mock all
+	$(MAKE) -C ./mock $(MAKECMDGOALS)
 
 .PHONY: test
 test:
-	@echo "\033[0;32mTEST:\033[0m"
+	@$(ECHO) "\033[0;32mTEST:\033[0m"
 	go test ./pkg/...
 
 .PHONY: publish
 publish:
-	@echo "\033[0;32mPublishing current release:\033[0m"
+	@$(ECHO) "\033[0;32mPublishing current release:\033[0m"
 	./scripts/publish.sh
 
 # The travis_* targets are entrypoints for CI.

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,17 +1,20 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
 TESTPARALLELISM=10
+ECHO=echo -e
 
 .PHONY: default
 default: banner dependencies lint build install
 
 .PHONY: all
-all: default examples
+all: default
 
 .PHONY: banner
 banner:
-	@echo "\033[1;37m======================\033[0m"
-	@echo "\033[1;37mPulumi Framework API package\033[0m"
-	@echo "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37mPulumi Framework API package\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
 
 .PHONY: dependencies
 dependencies:
@@ -19,27 +22,30 @@ dependencies:
 
 .PHONY: lint
 lint:
-	@echo "\033[0;32mLINT:\033[0m"
+	@$(ECHO) "\033[0;32mLINT:\033[0m"
 	@./node_modules/.bin/tslint ...
 
 .PHONY: build
 build:
-	@echo "\033[0;32mBUILD:\033[0m"
+	@$(ECHO) "\033[0;32mBUILD:\033[0m"
 	yarn link pulumi # ensure we link dependencies.
 	yarn run build   # compile the LumiPack
 
 .PHONY: install
 install:
-	@echo "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
+	@$(ECHO) "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
 	cp package.json bin/
 	cd bin/ && (yarn unlink || true) && yarn link # ensure NPM references resolve locally
 
-.PHONY: examples
-examples:
-#	@echo "\033[0;32mTEST EXAMPLES:\033[0m"
-#	go test -v -cover -timeout 1h -parallel ${TESTPARALLELISM} ./examples
+# The travis_* targets are entrypoints for CI.
+.PHONY: travis_cron
+travis_cron: all
 
-.PHONY: publish
-publish:
-#	@echo "\033[0;32mPublishing current release:\033[0m"
-#	../scripts/publish.sh
+.PHONY: travis_push
+travis_push: all
+
+.PHONY: travis_pull_request
+travis_pull_request: all
+
+.PHONY: travis_api
+travis_api: all

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -1,5 +1,8 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
 TESTPARALLELISM=10
+ECHO=echo -e
 
 .PHONY: default
 default: banner dependencies lint build install
@@ -9,9 +12,9 @@ all: default examples
 
 .PHONY: banner
 banner:
-	@echo "\033[1;37m======================\033[0m"
-	@echo "\033[1;37mPulumi Framework AWS implementation package\033[0m"
-	@echo "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37mPulumi Framework AWS implementation package\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
 
 .PHONY: dependencies
 dependencies:
@@ -19,24 +22,36 @@ dependencies:
 
 .PHONY: lint
 lint:
-	@echo "\033[0;32mLINT:\033[0m"
+	@$(ECHO) "\033[0;32mLINT:\033[0m"
 	@./node_modules/.bin/tslint ...
 
 .PHONY: build
 build:
-	@echo "\033[0;32mBUILD:\033[0m"
+	@$(ECHO) "\033[0;32mBUILD:\033[0m"
 	yarn link pulumi @pulumi/aws @pulumi/cloud # ensure we link dependencies.
 	yarn run build # compile the LumiPack
 
 .PHONY: install
 install:
-	@echo "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
+	@$(ECHO) "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
 	cp package.json bin/
 	cd bin/ && (yarn unlink || true) && yarn link # ensure NPM references resolve locally
 	cd ../api/bin/ && (yarn unlink @pulumi/cloud-aws || true) && yarn link @pulumi/cloud-aws #ensure loader can see this package
 
 .PHONY: examples
 examples:
-	@echo "\033[0;32mTEST EXAMPLES:\033[0m"
+	@$(ECHO) "\033[0;32mTEST EXAMPLES:\033[0m"
 	go test -v -cover -timeout 1h -parallel ${TESTPARALLELISM} ./examples
 
+# The travis_* targets are entrypoints for CI.
+.PHONY: travis_cron
+travis_cron: all
+
+.PHONY: travis_push
+travis_push: all
+
+.PHONY: travis_pull_request
+travis_pull_request: all
+
+.PHONY: travis_api
+travis_api: all

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,7 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
+ECHO=echo -e
 
 .PHONY: all
 all: crawler integration todo

--- a/examples/integration/Makefile
+++ b/examples/integration/Makefile
@@ -1,4 +1,7 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
+ECHO=echo -e
 TESTPARALLELISM=10
 
 .PHONY: default
@@ -9,9 +12,9 @@ all: default
 
 .PHONY: banner
 banner:
-	@echo "\033[1;37m======================\033[0m"
-	@echo "\033[1;37mPulumi Framework integration example\033[0m"
-	@echo "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37mPulumi Framework integration example\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
 
 .PHONY: dependencies
 dependencies:
@@ -20,13 +23,13 @@ dependencies:
 
 .PHONY: build
 build:
-	@echo "\033[0;32mBUILD:\033[0m"
+	@$(ECHO) "\033[0;32mBUILD:\033[0m"
 	yarn link pulumi @pulumi/cloud # ensure we link dependencies.
 	yarn run build # compile the LumiPack
 
 
 .PHONY: install
 install:
-	@echo "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
+	@$(ECHO) "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
 	cp package.json bin/
 	cd bin/ && (yarn unlink || true) && yarn link # ensure NPM references resolve locally

--- a/mock/Makefile
+++ b/mock/Makefile
@@ -1,5 +1,8 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
 TESTPARALLELISM=10
+ECHO=echo -e
 
 .PHONY: default
 default: banner dependencies lint build install integration
@@ -9,9 +12,9 @@ all: default tests
 
 .PHONY: banner
 banner:
-	@echo "\033[1;37m======================\033[0m"
-	@echo "\033[1;37mPulumi Framework mock implementation package\033[0m"
-	@echo "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37mPulumi Framework mock implementation package\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
 
 .PHONY: dependencies
 dependencies:
@@ -19,19 +22,19 @@ dependencies:
 
 .PHONY: lint
 lint:
-	@echo "\033[0;32mLINT:\033[0m"
+	@$(ECHO) "\033[0;32mLINT:\033[0m"
 	@./node_modules/.bin/tslint ...
 
 .PHONY: build
 build:
-	@echo "\033[0;32mBUILD:\033[0m"
+	@$(ECHO) "\033[0;32mBUILD:\033[0m"
 	yarn link pulumi @pulumi/cloud # ensure we link dependencies.
 	yarn run build # compile the LumiPack
 
 
 .PHONY: install
 install:
-	@echo "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
+	@$(ECHO) "\033[0;32mINSTALL:\033[0m [${LUMILIB}]"
 	cp package.json bin/
 	cd bin/ && (yarn unlink || true) && yarn link # ensure NPM references resolve locally
 	cd ../api/bin/ && (yarn unlink @pulumi/cloud-mock || true) && yarn link @pulumi/cloud-mock #ensure loader can see this package
@@ -43,15 +46,19 @@ tests:
 	cd tests/topic && yarn && yarn run build && yarn run test
 	cd tests/httpEndpoint && yarn && yarn run build && yarn run test
 
-
 .PHONY: integration
 integration:
 	$(MAKE) -C ./integration all
 
+# The travis_* targets are entrypoints for CI.
+.PHONY: travis_cron
+travis_cron: all
 
-.PHONY: publish
-publish:
-#publish:
-#	@echo "\033[0;32mPublishing current release:\033[0m"
-#	../scripts/publish.sh
-#.PHONY: publish
+.PHONY: travis_push
+travis_push: all
+
+.PHONY: travis_pull_request
+travis_pull_request: all
+
+.PHONY: travis_api
+travis_api: all

--- a/mock/integration/Makefile
+++ b/mock/integration/Makefile
@@ -1,4 +1,7 @@
+SHELL=/bin/bash
+.SHELLFLAGS=-ec
 PROCCNT=$(shell nproc --all)
+ECHO=echo -e
 TESTPARALLELISM=10
 
 .PHONY: default
@@ -9,9 +12,9 @@ all: default
 
 .PHONY: banner
 banner:
-	@echo "\033[1;37m======================\033[0m"
-	@echo "\033[1;37mPulumi Framework mock integration example\033[0m"
-	@echo "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
+	@$(ECHO) "\033[1;37mPulumi Framework mock integration example\033[0m"
+	@$(ECHO) "\033[1;37m======================\033[0m"
 
 
 .PHONY: dependencies
@@ -21,6 +24,6 @@ dependencies:
 
 .PHONY: build
 build:
-	@echo "\033[0;32mBUILD:\033[0m"
+	@$(ECHO) "\033[0;32mBUILD:\033[0m"
 	yarn link pulumi @pulumi/cloud @pulumi/integration-examples # ensure we link dependencies.
 	yarn run build


### PR DESCRIPTION
This logically reversts my previous change, moving us back to
$(MAKECMDGOALS). This was done so that `make` (which builds the
`default` target) does not build the `all` target in the
subprojects. This lets a subproject have different behavior between
make and make all (which the aws project uses to not build the
examples when only the default target is built).