### PR TITLE
Add a cloud.timer.hourly API

### DIFF
--- a/api/timer.ts
+++ b/api/timer.ts
@@ -22,16 +22,25 @@ export interface IntervalRate {
 }
 
 /**
- * DailySchedule describes a time of day ([[hourUTC]] and [[minuteUTC]]) at
- * which a timer should fire.
+ * DailySchedule describes a time of day ([[hourUTC]] and [[minuteUTC]]) at which a daily timer should fire.
  */
 export interface DailySchedule {
     /**
-     * The hour, in UTC, that the time should fire.
+     * The hour, in UTC, that the timer should fire.
      */
     hourUTC?: number;
     /**
-     * The minute, in UTC, that the time should fire.
+     * The minute, in UTC, that the timer should fire.
+     */
+    minuteUTC?: number;
+}
+
+/**
+ * HourlySchedule describes a time of the hour ([[minuteUTC]]) at which an hourly timer should fire.
+ */
+export interface HourlySchedule {
+    /**
+     * The minute, in UTC, that the timer should fire.
      */
     minuteUTC?: number;
 }
@@ -64,3 +73,13 @@ export let cron: { (name: string, cronTab: string, handler: () => Promise<void>)
  * @param handler A handler to invoke when the timer fires.
  */
 export let daily: { (name: string, schedule: DailySchedule, handler: () => Promise<void>): void };
+
+/**
+ * An hourly timer, firing at the specified UTC minute each hour.
+ *
+ * @param name The name of this timer.
+ * @param schedule The UTC minute at which to fire each day.
+ * @param handler A handler to invoke when the timer fires.
+ */
+export let hourly: { (name: string, schedule: HourlySchedule, handler: () => Promise<void>): void };
+

--- a/aws/examples/examples_test.go
+++ b/aws/examples/examples_test.go
@@ -101,6 +101,19 @@ func Test_Examples(t *testing.T) {
 				t.Logf("GET %v [%v]: %v", baseURL+"/todo", resp.StatusCode, string(bytes))
 			},
 		},
+		{
+			Dir: path.Join(cwd, "../../examples/timers"),
+			Config: map[string]string{
+				"aws:config:region":     region,
+				"cloud:config:provider": "aws",
+				"timers:config:message": "Hello, Pulumi Timers!",
+			},
+			Dependencies: []string{
+				"pulumi",
+				"@pulumi/cloud",
+				"@pulumi/cloud-aws",
+			},
+		},
 		// Leaving out of integration tests until we have shareable credentials for testing these integrations.
 	}
 	for _, ex := range examples {

--- a/aws/timer.ts
+++ b/aws/timer.ts
@@ -4,7 +4,7 @@ import * as aws from "@pulumi/aws";
 import { timer } from "@pulumi/cloud";
 import { LoggedFunction } from "./function";
 
-export function interval(name: string, options: timer.IntervalRate, handler: () => Promise<void>) {
+export function interval(name: string, options: timer.IntervalRate, handler: () => Promise<void>): void {
     let rateMinutes = 0;
     if (options.minutes) {
         rateMinutes += options.minutes;
@@ -25,14 +25,19 @@ export function interval(name: string, options: timer.IntervalRate, handler: () 
     createScheduledEvent(name, `rate(${rateMinutes} ${unit})`, handler);
 }
 
-export function cron(name: string, cronTab: string, handler: () => Promise<void>) {
+export function cron(name: string, cronTab: string, handler: () => Promise<void>): void {
     createScheduledEvent(name, `cron(${cronTab})`, handler);
 }
 
-export function daily(name: string, schedule: timer.DailySchedule, handler: () => Promise<void>) {
+export function daily(name: string, schedule: timer.DailySchedule, handler: () => Promise<void>): void {
     const hour = schedule.hourUTC || 0;
     const minute = schedule.minuteUTC || 0;
     cron(name, `${minute} ${hour} * * ? *`, handler);
+}
+
+export function hourly(name: string, schedule: timer.HourlySchedule, handler: () => Promise<void>): void {
+    const minute = schedule.minuteUTC || 0;
+    cron(name, `${minute} * * * ? *`, handler);
 }
 
 function createScheduledEvent(name: string, scheduleExpression: string, handler: () => Promise<void>) {

--- a/examples/timers/.gitignore
+++ b/examples/timers/.gitignore
@@ -1,0 +1,4 @@
+/.pulumi/
+/bin/
+/node_modules/
+

--- a/examples/timers/Pulumi.yaml
+++ b/examples/timers/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: timers
+runtime: nodejs
+

--- a/examples/timers/index.ts
+++ b/examples/timers/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as cloud from "@pulumi/cloud";
+import * as pulumi from "pulumi";
+
+let config = new pulumi.Config("timers:config");
+let message = config.require("message");
+
+cloud.timer.interval("test-interval", { minutes: 1 }, async () => {
+    console.log(`test-interval[${Date.now()}]: ${message}`);
+});
+
+cloud.timer.cron("test-cron", "* * * * ? *", async () => {
+    console.log(`test-cron[${Date.now()}]: ${message}`);
+});
+
+cloud.timer.daily("test-daily", { hourUTC: 7, minuteUTC: 30 }, async () => {
+    console.log(`test-daily[${Date.now()}]: ${message}`);
+});
+
+cloud.timer.hourly("test-hourly", { minuteUTC: 45 }, async () => {
+    console.log(`test-hourly[${Date.now()}]: ${message}`);
+});
+

--- a/examples/timers/package.json
+++ b/examples/timers/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "timer",
+    "version": "0.1",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^2.1.4"
+    },
+    "peerDependencies": {
+        "pulumi": "*",
+        "@pulumi/cloud": "*"
+    },
+    "dependencies": {
+        "@types/node": "^8.0.26"
+    }
+}

--- a/examples/timers/tsconfig.json
+++ b/examples/timers/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/mock/timer.ts
+++ b/mock/timer.ts
@@ -39,3 +39,9 @@ export function daily(name: string, schedule: timer.DailySchedule, handler: () =
     const minute = schedule.minuteUTC || 0;
     cron(name, `${minute} ${hour} * * ? *`, handler);
 }
+
+export function hourly(name: string, schedule: timer.HourlySchedule, handler: () => Promise<void>): void {
+    const minute = schedule.minuteUTC || 0;
+    cron(name, `${minute} * * * ? *`, handler);
+}
+


### PR DESCRIPTION
This adds a cloud.timer.hourly API, much like the existing
cloud.timer.daily, as a convenient shortcut.

I've also added some integration tests for timer APIs generally.