### PR TITLE
Add config as an input to `GetOperationsProviderForComponent`.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,6 +123,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4ff04b0f235c95c576084ace4ee2ef095ae7845f4c1654afdba6eec2ade5706"
+  inputs-digest = "b8d0e5becf06679f70941955b789a4f310e281e5237ec5ca7572fbc1f559ff0a"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
This is analogous to `ResourceProvider.Configure`, and allows the operations
provider to retrieve any configuration it needs to do its job. At the moment,
this is only used to discover the AWS region used by a particular set of
resources and create an appropriate session.