### PR TITLE
Permit imperative configuration of ECS clusters

### DIFF
--- a/aws/config/index.ts
+++ b/aws/config/index.ts
@@ -1,15 +1,30 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
+import * as aws from "@pulumi/aws";
 import * as pulumi from "pulumi";
 
 const config = new pulumi.Config("cloud-aws:config");
 
 // Optional ECS cluster ARN, subnets and VPC.  If not provided, `Service`s and
 // `Task`s are not available for the target environment.
-export let ecsClusterARN = config.get("ecsClusterARN");
-export let ecsClusterSubnets = config.get("ecsClusterSubnets");
-export let ecsClusterVpcId = config.get("ecsClusterVpcId");
+export let ecsClusterARN: string | pulumi.ComputedValue<string> = config.get("ecsClusterARN");
+export let ecsClusterSubnets: string | pulumi.ComputedValue<string>[] | undefined = config.get("ecsClusterSubnets");
+export let ecsClusterVpcId: string | pulumi.ComputedValue<string> = config.get("ecsClusterVpcId");
 
 // Optional EFS mount path on the cluster hosts.  If not provided, `Volumes`
 // cannot be used in `Service`s and `Task`s.
 export let ecsClusterEfsMountPath = config.get("ecsClusterEfsMountPath");
+
+// setEcsCluster configures the ambient ECS cluster imperatively rather than using standard configuration.
+export function setEcsCluster(cluster?: aws.ecs.Cluster, subnets?: aws.ec2.Subnet[], vpc?: aws.ec2.Vpc): void {
+    if (cluster) {
+        ecsClusterARN = cluster.name;
+    }
+    if (subnets) {
+        ecsClusterSubnets = subnets.map(s => s.id);
+    }
+    if (vpc) {
+        ecsClusterVpcId = vpc.id;
+    }
+}
+

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -12,8 +12,9 @@ export * from "./table";
 export * from "./topic";
 export * from "./service";
 export { onError } from "./unhandledError";
+import * as config from "./config";
 import * as timer from "./timer";
-export { timer };
+export { config, timer };
 
 // Code purely for enforcement that our module properly exports the same surface area as the API. We
 // don't ever actually pull in any value from these modules, so there is no actual dependency or


### PR DESCRIPTION
In addition to allowing the usual Pulumi configuration of ECS
clusters, this change allows you to configure them using an
imperative API, cloud.config.setEcsCluster.  This is a good
middle ground between separately provisioned ECS clusters and
automatically provisioned ones, and lets you version the cluster
alongside the services that use the cluster.  This is obviously
mostly for "simple" scenarios, since in real production cases,
you'll either want to use our fully hosted/managed ECS clusters,
or separate your own into an infrastructure layer that versions
independently from the application/service code.