### PR TITLE
Allow configuration of the IAM role policies for compute

### DIFF
--- a/aws/config/index.ts
+++ b/aws/config/index.ts
@@ -14,6 +14,11 @@ if (functionMemorySize % 64 !== 0 || functionMemorySize < 128 || functionMemoryS
     throw new Error("Lambda memory size in MiB must be a multiple of 64 between 128 and 1536.");
 }
 
+// Set the IAM role policies to apply to compute (both Lambda and ECS) within this Pulumi program.
+// The default is:
+// "arn:aws:iam::aws:policy/AWSLambdaFullAccess,arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess".
+export let computeIAMRolePolicyARNs = config.get("computeIAMRolePolicyARNs");
+
 // Optional ECS cluster ARN, subnets and VPC.  If not provided, `Service`s and
 // `Task`s are not available for the target environment.
 export let ecsClusterARN: string | pulumi.ComputedValue<string> = config.get("ecsClusterARN");

--- a/aws/function.ts
+++ b/aws/function.ts
@@ -5,7 +5,7 @@ import * as pulumi from "pulumi";
 import { functionMemorySize } from "./config";
 import { Network } from "./infrastructure/network";
 import { getLogCollector } from "./logCollector";
-import { getNetwork, runLambdaInVPC } from "./network";
+import { computePolicies, getNetwork, runLambdaInVPC } from "./shared";
 import { getUnhandledErrorTopic } from "./unhandledError";
 
 export { Context, Handler } from "@pulumi/aws/serverless";
@@ -28,10 +28,7 @@ export class Function extends pulumi.ComponentResource {
             () => {
                 // First allocate a function.
                 const options: aws.serverless.FunctionOptions = {
-                    policies: [
-                        aws.iam.AWSLambdaFullAccess,
-                        aws.iam.AmazonEC2ContainerServiceFullAccess,
-                    ],
+                    policies: computePolicies,
                     deadLetterConfig: {
                         targetArn: getUnhandledErrorTopic().arn,
                     },

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -8,7 +8,7 @@ import * as stream from "stream";
 import * as tar from "tar";
 import { Cluster } from "./infrastructure/cluster";
 import { Network } from "./infrastructure/network";
-import { getCluster, getNetwork } from "./network";
+import { computePolicies, getCluster, getNetwork } from "./shared";
 
 // For type-safety purposes, we want to be able to mark some of our types with typing information
 // from other libraries.  However, we don't want to actually import those libraries, causing those
@@ -462,10 +462,7 @@ function getTaskRole(): aws.iam.Role {
         });
         // TODO[pulumi/pulumi-cloud#145]: These permissions are used for both Lambda and ECS compute.
         // We need to audit these permissions and potentially provide ways for users to directly configure these.
-        const policies = [
-            aws.iam.AWSLambdaFullAccess,
-            aws.iam.AmazonEC2ContainerServiceFullAccess,
-        ];
+        const policies = computePolicies;
         for (let i = 0; i < policies.length; i++) {
             const _ = new aws.iam.RolePolicyAttachment(`pulumi-task-iampolicy-${i}`, {
                 role: taskRole,

--- a/aws/shared.ts
+++ b/aws/shared.ts
@@ -1,11 +1,21 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
+import * as aws from "@pulumi/aws";
 import * as config from "./config";
 import { Cluster } from "./infrastructure/cluster";
 import { Network } from "./infrastructure/network";
 
 // Whether or not we should run lamabda-based compute in the private network
 export let runLambdaInVPC: boolean = config.usePrivateNetwork;
+
+// The IAM Role Policies to apply to compute for both Lambda and ECS
+const defaultComputePolicies = [
+    aws.iam.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
+    aws.iam.AmazonEC2ContainerServiceFullAccess, // Required for lambda compute to be able to discover ECS endpoints
+];
+export let computePolicies: aws.ARN[] = config.computeIAMRolePolicyARNs
+    ? config.computeIAMRolePolicyARNs.split(",")
+    : defaultComputePolicies;
 
 // The network to use for container (and possibly lambda) compute or undefined if containers are unsupported and
 // lambdas are being run outsie a VPC.


### PR DESCRIPTION
Accepts a comma-separated list of IAM managed policy ARNs to use instead of the default policy.

This is applied to all Pulumi compute (Lambda Functions and ECS Tasks).