### PR TITLE
Build containers, even during 1st-time previews

### DIFF
--- a/api/service.ts
+++ b/api/service.ts
@@ -28,26 +28,28 @@ export interface HostProperties {
  */
 export interface Container {
     /**
-     * The image to use for the container. Exactly one of `image`, `build`, and
-     * `function` must be specified.
+     * The image to use for the container.  If `image` is specified, but not `build`, the image will be
+     * pulled from the Docker Hub.  If `image` *and* `build` are specified, the `image` controls the
+     * resulting image tag for the build image that gets pushed.
      */
     image?: string;
     /**
-     * A path to a folder within the current program directory where a Docker
-     * build should be run to construct the image for this Container. Exactly
-     * one of `image`, `build`, and `function` must be specified.
+     * A path to a folder within the current program directory where a Docker build should be run to
+     * construct the image for this Container.  If `image` is also specified, the built container will
+     * be tagged with that name, but otherwise will get an auto-generated image name.
      */
     build?: string;
+    /**
+     * The function code to use as the implementation of the contaner.  If `function` is specified,
+     * neither `image` nor `build` are legal.
+     */
+    function?: () => void;
+
     /**
      * Optional environment variables to set and make available to the container
      * as it is running.
      */
     environment?: {[name: string]: pulumi.ComputedValue<string>};
-    /**
-     * The function code to use as the implementation of the contaner. Exactly
-     * one of `image`, `build`, and `function` must be specified.
-     */
-    function?: () => void;
     /**
      * The maximum amount of memory the container will be allowed to use. Maps to the Docker
      * `--memory` option - see

--- a/examples/containers/index.ts
+++ b/examples/containers/index.ts
@@ -192,3 +192,15 @@ api.get("/custom", async (req, res) => {
     }
 });
 api.publish().url.then(url => console.log(`Serving at: ${url}`));
+
+let builtNamedService = new cloud.Service("nginx3", {
+    containers: {
+        nginx: {
+            build: "./app",
+            image: "pulumi/nginx",
+            memory: 128,
+            ports: [{ port: 80 }],
+        },
+    },
+    replicas: 2,
+});


### PR DESCRIPTION
The prior code wouldn't build containers until we had a repository URL
in hand, which meant until an actual deployment had occurred, we would
skip several arguably important steps.  (E.g., you wouldn't find Docker
build failures until attempting to deploy.)

This change builds the image even the first time around, using our
automatic name for it.  It then explicitly tags the result, when it has
the repository URL, and pushes that.

We also now permit you to specify an image *and* a build directory and
we will use that image rather than auto- computing it.