### PR TITLE
Use repository name in TaskDefinition

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -344,7 +344,7 @@ async function buildAndPushImage(imageName: string, container: cloud.Container,
         true,
     );
     if (inspectResult.code || !inspectResult.stdout) {
-        throw new Error(`No digest available for image ${imageName}`);
+        throw new Error(`No digest available for image ${imageName}: ${inspectResult.code} -- ${inspectResult.stdout}`);
     }
     return inspectResult.stdout.trim();
 }


### PR DESCRIPTION
We need to use the repository name in the task definition so that we can access the image from ECR.