### PR TITLE
Include the mock package as part of the release

### DIFF
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -26,6 +26,7 @@ copy_package() {
 # Copy the two packages
 copy_package "${ROOT}/api/bin/." "@pulumi/cloud"
 copy_package "${ROOT}/aws/bin/." "@pulumi/cloud-aws"
+copy_package "${ROOT}/mock/bin/." "@pulumi/cloud-mock"
 
 # Tar up the file and then print it out for use by the caller or script.
 tar -czf ${PUBFILE} -C ${PUBDIR} .


### PR DESCRIPTION
Doing this will mean it will flow to the installer so folks can use this package when downloading Pulumi binaries.  @subhabh noticed this was missing.