### PR TITLE
Capture debug output in the container test.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -281,7 +281,7 @@
   branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = ["pkg/compiler/errors","pkg/component","pkg/diag","pkg/diag/colors","pkg/encoding","pkg/engine","pkg/pack","pkg/pulumiframework","pkg/resource","pkg/resource/config","pkg/resource/deploy","pkg/resource/plugin","pkg/resource/provider","pkg/resource/stack","pkg/testing","pkg/testing/integration","pkg/tokens","pkg/util/cmdutil","pkg/util/contract","pkg/util/fsutil","pkg/util/mapper","pkg/util/rpcutil","pkg/workspace","sdk/proto/go"]
-  revision = "e9d13dd40f4de7f1e0e93fe3f9c2160e4a972ac7"
+  revision = "be8d604c96edb85409b565f142f7090ccb7a463a"
 
 [[projects]]
   branch = "master"

--- a/aws/examples/examples_test.go
+++ b/aws/examples/examples_test.go
@@ -63,6 +63,7 @@ func Test_Examples(t *testing.T) {
 			Dependencies: []string{
 				"@pulumi/cloud",
 			},
+			DebugUpdates: true,
 			ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
 				_, _, snapshot, err := stack.DeserializeCheckpoint(&checkpoint)
 				if !assert.Nil(t, err, "expected checkpoint deserialization to succeed") {


### PR DESCRIPTION
This requires updating which version of `pulumi/pulumi` we are using.