### PR TITLE
Use `--password-stdin` where available.

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -7,6 +7,7 @@ export PATH := $(shell yarn bin 2>/dev/null):$(PATH)
 TESTPARALLELISM := 10
 
 build::
+	yarn install
 	yarn link pulumi @pulumi/aws @pulumi/cloud
 	tsc
 

--- a/aws/package.json
+++ b/aws/package.json
@@ -5,6 +5,7 @@
         "@types/aws-sdk": "^2.7.0",
         "@types/node": "^8.0.26",
         "@types/mime": "^2.0.0",
+        "@types/semver": "^5.4.0",
         "tslint": "^5.7.0",
         "typescript": "^2.5.2"
     },
@@ -14,6 +15,7 @@
         "pulumi": "*"
     },
     "dependencies": {
-        "mime": "^2.0.3"
+        "mime": "^2.0.3",
+        "semver": "^5.4.0"
     }
 }

--- a/aws/yarn.lock
+++ b/aws/yarn.lock
@@ -16,6 +16,10 @@
   version "8.0.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.47.tgz#968e596f91acd59069054558a00708c445ca30c2"
 
+"@types/semver@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.4.0.tgz#f3658535af7f1f502acd6da7daf405ffeb1f7ee4"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -234,7 +238,7 @@ sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
-semver@^5.3.0:
+semver@^5.3.0, semver@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 


### PR DESCRIPTION
Docker 17.07+ has deprecated the `--password` parameter to `docker
login` in favor of `--password-stdin`. These changes update the AWS
implementation of `cloud.Service` to check which version of Docker is in
use during a build and pass `--password-stdin` if the version is 17.07
or later.