### PR TITLE
Re-enable ExtraRuntimeValidation

### DIFF
--- a/aws/examples/examples_test.go
+++ b/aws/examples/examples_test.go
@@ -75,7 +75,7 @@ func Test_Examples(t *testing.T) {
 				if !assert.NotNil(t, endpoint, "expected to find endpoint") {
 					return
 				}
-				baseURL := endpoint.State.Outputs["url"].StringValue()
+				baseURL := endpoint.State.Inputs["url"].StringValue()
 				assert.NotEmpty(t, baseURL, "expected a `containers` endpoint")
 
 				// Validate the GET /test endpoint
@@ -159,7 +159,7 @@ func Test_Examples(t *testing.T) {
 				if !assert.NotNil(t, endpoint, "expected to find endpoint") {
 					return
 				}
-				baseURL := endpoint.State.Outputs["url"].StringValue()
+				baseURL := endpoint.State.Inputs["url"].StringValue()
 				assert.NotEmpty(t, baseURL, "expected a `todo` endpoint")
 
 				// Validate the GET / endpoint
@@ -274,7 +274,7 @@ func testURLGet(t *testing.T, checkpoint stack.Checkpoint, path string, contents
 	if !assert.NotNil(t, endpoint, "expected to find 'test' endpoint") {
 		return
 	}
-	baseURL := endpoint.State.Outputs["url"].StringValue()
+	baseURL := endpoint.State.Inputs["url"].StringValue()
 	assert.NotEmpty(t, baseURL, "expected an `test` endpoint")
 
 	// Validate the GET /test1.txt endpoint

--- a/aws/tests/unit_and_performance_test.go
+++ b/aws/tests/unit_and_performance_test.go
@@ -81,7 +81,7 @@ func Test_Performance(t *testing.T) {
 				if !assert.NotNil(t, endpoint, "expected to find endpoint") {
 					return
 				}
-				baseURL := endpoint.State.Outputs["url"].StringValue()
+				baseURL := endpoint.State.Inputs["url"].StringValue()
 				assert.NotEmpty(t, baseURL, "expected a `todo` endpoint")
 
 				// Validate the GET /perf endpoint
@@ -162,7 +162,7 @@ func hitUnitTestsEndpoint(
 	if !assert.NotNil(t, endpoint, "expected to find endpoint") {
 		return
 	}
-	baseURL := endpoint.State.Outputs["url"].StringValue()
+	baseURL := endpoint.State.Inputs["url"].StringValue()
 	assert.NotEmpty(t, baseURL, fmt.Sprintf("expected a `%v` endpoint", endpointName))
 
 	// Validate the GET /unittests endpoint


### PR DESCRIPTION
Use the new resource component model type names for HttpEndpoints -`cloud:http:HttpEndpoint`.

Fixes https://github.com/pulumi/pulumi-aws/issues/80.