### PR TITLE
Pass deleteOnTermination to our cluster's EBS volumes

### DIFF
--- a/aws/infrastructure/cluster.ts
+++ b/aws/infrastructure/cluster.ts
@@ -226,11 +226,13 @@ export class Cluster {
                     deviceName: "/dev/xvdb",
                     volumeSize: 5, // GB
                     volumeType: "gp2", // default is "standard"
+                    deleteOnTermination: true,
                 },
                 {
                     deviceName: "/dev/xvdcz",
                     volumeSize: 50,
                     volumeType: "gp2",
+                    deleteOnTermination: true,
                 },
             ],
             securityGroups: [ instanceSecurityGroup.id ],


### PR DESCRIPTION
We didn't pass deleteOnTermination to our ECS cluster's EBS volumes,
which meant we were leaking them upon delete.  These are ephemeral and
so it's safe for us to bank the $$$ and delete them.

Fixes pulumi/pulumi-cloud#222.