### PR TITLE
Allow configuring AWS IAM role programmatically

### DIFF
--- a/aws/function.ts
+++ b/aws/function.ts
@@ -5,7 +5,7 @@ import * as pulumi from "pulumi";
 import { functionMemorySize } from "./config";
 import { Network } from "./infrastructure/network";
 import { getLogCollector } from "./logCollector";
-import { computePolicies, getNetwork, runLambdaInVPC } from "./shared";
+import { getComputeIAMRolePolicies, getNetwork, runLambdaInVPC } from "./shared";
 import { getUnhandledErrorTopic } from "./unhandledError";
 
 export { Context, Handler } from "@pulumi/aws/serverless";
@@ -23,7 +23,7 @@ export class Function extends pulumi.ComponentResource {
 
         // First allocate a function.
         const options: aws.serverless.FunctionOptions = {
-            policies: [...computePolicies],
+            policies: [...getComputeIAMRolePolicies()],
             deadLetterConfig: {
                 targetArn: getUnhandledErrorTopic().arn,
             },

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -16,6 +16,9 @@ import * as config from "./config";
 import * as timer from "./timer";
 export { config, timer };
 
+// This is an AWS-only API that allows configuring AWS-specific role policies.
+export { setComputeIAMRolePolicies } from "./shared";
+
 // Code purely for enforcement that our module properly exports the same surface area as the API. We
 // don't ever actually pull in any value from these modules, so there is no actual dependency or
 // cost here.  This code can also go into a separate file if we don't want it cluttering this one.

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -11,8 +11,8 @@ import * as config from "./config";
 import { Cluster } from "./infrastructure/cluster";
 import { Network } from "./infrastructure/network";
 import { getLogCollector } from "./logCollector";
-// tslint:disable-next-line:max-line-length
-import { computePolicies, createNameWithStackInfo, getCluster, getGlobalInfrastructureResource, getNetwork } from "./shared";
+import { createNameWithStackInfo, getCluster, getComputeIAMRolePolicies,
+         getGlobalInfrastructureResource, getNetwork } from "./shared";
 import { sha1hash } from "./utils";
 
 // For type-safety purposes, we want to be able to mark some of our types with typing information
@@ -688,7 +688,7 @@ function getTaskRole(): aws.iam.Role {
         }, getGlobalInfrastructureResource());
         // TODO[pulumi/pulumi-cloud#145]: These permissions are used for both Lambda and ECS compute.
         // We need to audit these permissions and potentially provide ways for users to directly configure these.
-        const policies = computePolicies;
+        const policies = getComputeIAMRolePolicies();
         for (let i = 0; i < policies.length; i++) {
             const policyArn = policies[i];
             const _ = new aws.iam.RolePolicyAttachment(

--- a/aws/shared.ts
+++ b/aws/shared.ts
@@ -55,9 +55,25 @@ const defaultComputePolicies = [
     aws.iam.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
     aws.iam.AmazonEC2ContainerServiceFullAccess, // Required for lambda compute to be able to run Tasks
 ];
-export let computePolicies: aws.ARN[] = config.computeIAMRolePolicyARNs
+let computePolicies: aws.ARN[] = config.computeIAMRolePolicyARNs
     ? config.computeIAMRolePolicyARNs.split(",")
     : defaultComputePolicies;
+let computePoliciesAccessed = false;
+
+// Set the IAM policies to use for compute.
+export function setComputeIAMRolePolicies(policyARNs: string[]) {
+    if (computePoliciesAccessed) {
+        throw new Error(
+            "The compute policies have already been used, make sure you are setting IAM policies early enough.");
+    }
+    computePolicies = policyARNs;
+}
+
+// Get the IAM policies to use for compute.
+export function getComputeIAMRolePolicies(): aws.ARN[] {
+    computePoliciesAccessed = true;
+    return computePolicies;
+}
 
 // The network to use for container (and possibly lambda) compute or undefined if containers are unsupported and
 // lambdas are being run outsie a VPC.


### PR DESCRIPTION
We previously allowed AWS-specific configuration only through Pulumi config.  This is quite limiting, and prevents cases where AWS resources need to be created as part of a Pulumi program and then used as art of initializing the `@pulumi/cloud` AWS implementation.

With this change, we introduce a first AWS-specific API `setComputeIAMRolePolicies`. This can be accessed explicitly via the `@pulumi/cloud-aws` package.