### PR TITLE
Exclude non-Node libraries from tsconfig in examples

### DIFF
--- a/examples/containers/tsconfig.json
+++ b/examples/containers/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/countdown/tsconfig.json
+++ b/examples/countdown/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/crawler/tsconfig.json
+++ b/examples/crawler/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/httpEndpoint/tsconfig.json
+++ b/examples/httpEndpoint/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/integration/tsconfig.json
+++ b/examples/integration/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/timers/tsconfig.json
+++ b/examples/timers/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],         
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/todo/tsconfig.json
+++ b/examples/todo/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],        
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,


### PR DESCRIPTION
Fixes part of https://github.com/pulumi/home/issues/88