### PR TITLE
Increase service deregistration delay

### DIFF
--- a/api/service.ts
+++ b/api/service.ts
@@ -55,7 +55,7 @@ export interface Container {
      * `--memory` option - see
      * https://docs.docker.com/engine/reference/commandline/run.
      */
-    memory?: number;
+    memory?: pulumi.ComputedValue<number>;
     /**
      * The amount of memory to reserve for the container, but the container will
      * be allowed to use more memory if it's available.  At least one of
@@ -63,7 +63,7 @@ export interface Container {
      * `--memory-reservation` option - see
      * https://docs.docker.com/engine/reference/commandline/run.
      */
-    memoryReservation?: number;
+    memoryReservation?: pulumi.ComputedValue<number>;
     /**
      * An array of ports to publish from the container.  Ports are exposed using the TCP protocol.  If the [external]
      * flag is true, the port will be exposed to the Internet even if the service is running in a private network.
@@ -88,7 +88,7 @@ export interface Container {
      * information about the Docker `CMD` parameter, go to
      * https://docs.docker.com/engine/reference/builder/#cmd.
      */
-    command?: string[];
+    command?: pulumi.ComputedValue<string[]>;
 }
 
 export interface ContainerPort {


### PR DESCRIPTION
We have seen cases where the 30s delay between LB deregistration and stopping the container is not enough for the new copy of the service to be active, leading to downtime during updates.  This is not a full solution to pulumi/pulumi-ppc#139, but should help avoid serious issues until we can reactor the PPC.  It also provides a less surprising default for the cloud framework.

Also allow promises for a few additional container inputs, and expose a few additional properties on the AWS variant of the cloud Service.