### PR TITLE
Reduce number of AZs used for containers test

### DIFF
--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -167,7 +167,7 @@ func Test_Examples(t *testing.T) {
 			Config: map[string]string{
 				"aws:config:region":                                            region,
 				"cloud-aws:config:ecsAutoCluster":                              "true",
-				"cloud-aws:config:ecsAutoClusterNumberOfAZs":                   "3",
+				"cloud-aws:config:ecsAutoClusterNumberOfAZs":                   "2",
 				"cloud-aws:config:ecsAutoClusterInstanceRootVolumeSize":        "80",
 				"cloud-aws:config:ecsAutoClusterInstanceDockerImageVolumeSize": "100",
 				"cloud-aws:config:ecsAutoClusterInstanceSwapVolumeSize":        "1",


### PR DESCRIPTION
Reduce from 3 to 1.  This reduces integration test time by ~30 minutes, and also validates that we support single AZ operation, which we do not validate elsewhere.