### PR TITLE
Export the infrastructure module

### DIFF
--- a/aws/index.ts
+++ b/aws/index.ts
@@ -13,8 +13,9 @@ export * from "./topic";
 export * from "./service";
 export { onError } from "./unhandledError";
 import * as config from "./config";
+import * as infrastructure from "./infrastructure";
 import * as timer from "./timer";
-export { config, timer };
+export { config, infrastructure, timer };
 
 // This is an AWS-only API that allows configuring AWS-specific role policies.
 export { setComputeIAMRolePolicies } from "./shared";
@@ -36,4 +37,3 @@ apiShape = thisShape;
 // uncomment it because our use of private members in classes *does* mean that we're effectively
 // exporting a larger surface area.  We can solve this in the future by using the IIFE pattern.
 // thisShape = frameworkShape;
-

--- a/aws/infrastructure/index.ts
+++ b/aws/infrastructure/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+export * from "./cluster";
+export * from "./network";


### PR DESCRIPTION
This exports the infrastructure module so that developers coding
directly against the @pulumi/cloud-aws package can access some
internals that are helpful to them.

This is a small step towards #309.