### PR TITLE
Set `Content-Length` in AWS HTTP endpoints.

### DIFF
--- a/aws/httpEndpoint.ts
+++ b/aws/httpEndpoint.ts
@@ -719,6 +719,11 @@ function apiGatewayToRequestResponse(ev: APIGatewayRequest, body: any,
         headers: <{[header: string]: string}>{},
         body: Buffer.from([]),
     };
+
+    if (body && body.length) {
+        ev.headers["Content-Length"] = body.length;
+    }
+
     const req: cloud.Request = {
         headers: ev.headers,
         body: body,


### PR DESCRIPTION
This header is not provided by the API Gateway Lambda integration.
Instead, we must set it ourselves based on the size of the request body.