### PR TITLE
Normalize header names and inject content-length

### DIFF
--- a/api/httpEndpoint.ts
+++ b/api/httpEndpoint.ts
@@ -24,6 +24,10 @@ export interface Request {
      */
     headers: { [header: string]: string | string[]; };
     /**
+     * The headers of the HTTP request.
+     */
+    rawHeaders: string[];
+    /**
      * The query parameters parsed from the query string of the request URL.
      */
     query: { [query: string]: string | string[]; };

--- a/examples/todo/middleware.ts
+++ b/examples/todo/middleware.ts
@@ -3,7 +3,7 @@
 import * as cloud from "@pulumi/cloud";
 
 export let authMiddleware: cloud.RouteHandler = (req, res, next) => {
-    let auth = req.headers["Authorization"];
+    let auth = req.headers["authorization"];
     if (auth !== "Bearer SECRETPASSWORD") {
         res.status(401).end("Authorization header required");
         return;

--- a/mock/httpEndpoint.ts
+++ b/mock/httpEndpoint.ts
@@ -116,6 +116,7 @@ export class HttpEndpoint implements cloud.HttpEndpoint {
                 method: expressRequest.method,
                 params: expressRequest.params,
                 headers: expressRequest.headers,
+                rawHeaders: expressRequest.rawHeaders,
                 query: expressRequest.query,
                 path:   expressRequest.path,
                 protocol: expressRequest.protocol,


### PR DESCRIPTION
Add the content-length header into requests, since API Gateway strips this out.

Also normalize header names using `toLowerCase` match Node.js request object header behaviour.  And adds the `rawHeaders` proeprty with the raw array of header name/values.

Replaces #314.