### PR TITLE
Allow externally providing public subnet IDs

### DIFF
--- a/aws/config/index.ts
+++ b/aws/config/index.ts
@@ -59,17 +59,25 @@ export let externalVpcId = config.get("externalVpcId");
 
 const externalSubnetsString = config.get("externalSubnets");
 /**
- * Provvide subnets ids for the VPC as a comma-seperated string.  Required if using an existing VPC.
+ * Provide subnets ids for the VPC as a comma-seperated string.  Required if using an existing VPC.
  */
-
 export let externalSubnets: string[] | undefined = undefined;
 if (externalSubnetsString) {
     externalSubnets = externalSubnetsString.split(",");
 }
 
+const externalPublicSubnetsString = config.get("externalPublicSubnets");
+/**
+ * Provide public subnets ids for the VPC as a comma-seperated string.  Required if using an existing VPC.
+ */
+export let externalPublicSubnets: string[] | undefined = undefined;
+if (externalPublicSubnetsString) {
+    externalPublicSubnets = externalPublicSubnetsString.split(",");
+}
+
 const externalSecurityGroupsString = config.get("externalSecurityGroups");
 /**
- * Provvide securityGroup ids for the VPC as a comma-seperated string.  Required if using an existing VPC.
+ * Provide securityGroup ids for the VPC as a comma-seperated string.  Required if using an existing VPC.
  */
 export let externalSecurityGroups: string[] | undefined = undefined;
 if (externalSecurityGroupsString) {

--- a/aws/shared.ts
+++ b/aws/shared.ts
@@ -94,9 +94,10 @@ export function getNetwork(): Network | undefined {
                 numberOfAvailabilityZones: config.ecsAutoCluster ? config.ecsAutoClusterNumberOfAZs : undefined,
             });
         } else if (config.externalVpcId) {
-            if (!config.externalSubnets || !config.externalSecurityGroups) {
+            if (!config.externalSubnets || !config.externalSecurityGroups || !config.externalPublicSubnets) {
                 throw new Error(
-                    "If providing 'externalVpcId', must provide 'externalSubnets' and 'externalSecurityGroups'");
+                    "If providing 'externalVpcId', must provide 'externalSubnets', " +
+                    "'externalPublicSubnets' and 'externalSecurityGroups'");
             }
             // Use an exsting VPC for this private network
             network = {
@@ -104,8 +105,7 @@ export function getNetwork(): Network | undefined {
                 vpcId: Promise.resolve(config.externalVpcId),
                 privateSubnets: config.usePrivateNetwork,
                 subnetIds: config.externalSubnets.map(s => Promise.resolve(s)),
-                // TODO: Do we need separate config?
-                publicSubnetIds: config.externalSubnets.map(s => Promise.resolve(s)),
+                publicSubnetIds: config.externalPublicSubnets.map(s => Promise.resolve(s)),
                 securityGroupIds: config.externalSecurityGroups.map(s => Promise.resolve(s)),
             };
         }


### PR DESCRIPTION
When using an externally provided network, allow specifying the private and public subnets separately.