### PR TITLE
Check that worktree is clean before running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ install:
     - git clone git@github.com:pulumi/home ${GOPATH}/src/github.com/pulumi/home
     - ${GOPATH}/src/github.com/pulumi/home/scripts/install-locked.sh ${PULUMI_ROOT} pulumi pulumi-aws
     - make ensure
+before_script:
+    # Ensure the working tree is clean (make ensure may have updated lock files)
+    - ${GOPATH}/src/github.com/pulumi/home/scripts/check-worktree-is-clean.sh
 script:
     - make travis_${TRAVIS_EVENT_TYPE}
 notifications:


### PR DESCRIPTION
Without this, we miss cases where the lock files may need to be
updated and we encode a version like v0.9.5-dirty.