### PR TITLE
Add stack to Name tag on Pulumi-created VPCs

### DIFF
--- a/aws/infrastructure/network.ts
+++ b/aws/infrastructure/network.ts
@@ -37,7 +37,7 @@ export class Network {
             enableDnsHostnames: true,
             enableDnsSupport: true,
             tags: {
-                Name: "Pulumi VPC",
+                Name: `Pulumi VPC - ${pulumi.getStack()}`,
             },
         });
         this.vpcId = vpc.id;


### PR DESCRIPTION
If a customer runs into their VPC limit on AWS, they don't have any information to go on in order to see if any of them can safely be removed. e.g. 

![image](https://user-images.githubusercontent.com/4029847/34503493-72954c50-efcd-11e7-917c-feb119dfdafe.png)

I'm not sure this is the right (or even appropriate) solution to the problem. So feel free to throw out better alternatives.