### PR TITLE
Expose AWS resources for cloud.Task

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -208,7 +208,7 @@ interface ContainerPortLoadBalancer {
 
 // createLoadBalancer allocates a new Load Balancer TargetGroup that can be attached to a Service container and port
 // pair. Allocates a new NLB is needed (currently 50 ports can be exposed on a single NLB).
-function newLoadBalancerTargetGroup(parent: pulumi.Resource, cluster: awsinfra.Cluster, 
+function newLoadBalancerTargetGroup(parent: pulumi.Resource, cluster: awsinfra.Cluster,
                                     portMapping: cloud.ContainerPort): ContainerPortLoadBalancer {
     const network: awsinfra.Network | undefined = getNetwork();
     if (!network) {


### PR DESCRIPTION
Extends the work done to expose AWS implementation details in #316 to also include cloud.Task.  We exposed similar properties on cloud.Service with the previous change, but missed exposing these for cloud.Task.

We expect to use this as part of enabling our PPC update isolation work.

Fixes #337.