### PR TITLE
Update pulumi/pulumi reference in pulumi-cloud

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -488,7 +488,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "bd4cd2fda95cc52640b82a400c7ea012fbb18575"
+  revision = "4c217fd358f301e48b4422a71022225950ac2f57"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-aws"
@@ -696,6 +696,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7598c3a844dd8562fa6feaac200c5280e8e986cf9ba6c6b77e590a155adb42da"
+  inputs-digest = "78506f8f3b3fb249c70d16069e5ababc82c20e3625f49e7f28618518a4c62872"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,7 +2,7 @@ required = ["github.com/pulumi/pulumi-aws"]
 
 [[override]]
   name = "github.com/pulumi/pulumi"
-  revision = "bd4cd2fda95cc52640b82a400c7ea012fbb18575"
+  revision = "4c217fd358f301e48b4422a71022225950ac2f57"
 
 [[override]]
   name = "github.com/pulumi/pulumi-aws"


### PR DESCRIPTION
Update the reference to `pulumi/pulumi`.

I would like to do this so I can depend on that commit (actually https://github.com/pulumi/pulumi/commit/001d187c90fd420df75d0a71e64ddc8b0cd46d68, from a few days before) in the `pulumi-ppc` repo. But that requires a new build of the SDK, etc. etc.
