### PR TITLE
Task#run should throw on failure

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -1013,7 +1013,7 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
             }
 
             // Run the task
-            await ecs.runTask({
+            const res = await ecs.runTask({
                 cluster: (await clusterARN)!,
                 taskDefinition: (await taskDefinitionArn)!,
                 placementConstraints: placementConstraintsForHost(options && options.host),
@@ -1026,6 +1026,9 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
                     ],
                 },
             }).promise();
+            if (res.failures && res.failures.length > 0) {
+                throw new Error("Failed to start task:" + JSON.stringify(res.failures, null, ""));
+            }
         };
     }
 }

--- a/aws/tests/unit/serviceTests.ts
+++ b/aws/tests/unit/serviceTests.ts
@@ -61,6 +61,17 @@ namespace basicTests {
             await testEndpointShouldExistAndReturn200(endpoint);
         }));
     }
+    
+
+    const task = new cloud.Task("task-runfailure", {
+        image: "nginx",
+        memory: 100*1024, // Intentionaly ask for more memory than is available in the cluster to trigger error.
+    });
+
+    export async function testTaskRunFailure() {
+        await harness.assertThrowsAsync(async () => await task.run());
+    }
+
 }
 
 export async function runAllTests(result: any): Promise<boolean>{


### PR DESCRIPTION
We were silently ignoring failures to run a task.

Fixes #368.