### PR TITLE
Support custom Docker build args (#362)

### DIFF
--- a/api/service.ts
+++ b/api/service.ts
@@ -34,11 +34,11 @@ export interface Container {
      */
     image?: string;
     /**
-     * A path to a folder within the current program directory where a Docker build should be run to
-     * construct the image for this Container.  If `image` is also specified, the built container will
-     * be tagged with that name, but otherwise will get an auto-generated image name.
+     * Either a path to a folder in which a Docker build should be run to construct the image for this
+     * Container, or a ContainerBuild object with more detailed build instructions.  If `image` is also specified, the
+     * built container will be tagged with that name, but otherwise will get an auto-generated image name.
      */
-    build?: string;
+    build?: string | ContainerBuild;
     /**
      * The function code to use as the implementation of the contaner.  If `function` is specified,
      * neither `image` nor `build` are legal.
@@ -89,6 +89,29 @@ export interface Container {
      * https://docs.docker.com/engine/reference/builder/#cmd.
      */
     command?: pulumi.ComputedValue<string[]>;
+}
+
+/**
+ * ContainerBuild may be used to specify detailed instructions about how to build a container.
+ */
+export interface ContainerBuild {
+    /**
+     * context is a path to a directory to use for the Docker build context, usually the directory in which the
+     * Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice).
+     * If not specified, the context defaults to the current working directory; if a relative path is used, it
+     * is relative to the current working directory that Pulumi is evaluating.
+     */
+    context?: string;
+    /**
+     * dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed
+     * to be a file named Dockerfile in the root of the build context.
+     */
+    dockerfile?: string;
+    /**
+     * An optional map of named build-time argument variables to set during the Docker build.  This flag allows you
+     * to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+     */
+    args?: {[key: string]: string};
 }
 
 export interface ContainerPort {

--- a/examples/containers/app2/Dockerfile-alt
+++ b/examples/containers/app2/Dockerfile-alt
@@ -1,0 +1,2 @@
+FROM nginx
+COPY ./app/content /usr/share/nginx/html

--- a/examples/containers/index.ts
+++ b/examples/containers/index.ts
@@ -147,6 +147,19 @@ let builtNamedService = new cloud.Service("examples-pulumiNginx", {
     replicas: 2,
 });
 
+const builtNamedService2 = new cloud.Service("examples-pulumiNginx2", {
+    containers: {
+        nginx: {
+            build: {
+                dockerfile: "./app2/Dockerfile-alt",
+                args: { "FOO": "bar" },
+            },
+            memory: 128,
+            ports: [{ port: 80 }],
+        },
+    },
+});
+
 // use a pre-built nginx image, and expose it via a TCP network load balancer (the default).
 let nginxOverNetLB = new cloud.Service("examples-nginxOverNetLB", {
     containers: {


### PR DESCRIPTION
This change adds support for custom Docker build args.  This is "inspired
by" Docker Compose's approach of permitting you to either just specify a
string -- which is interpreted as the context -- or a bag of options.  The
options specified may contain the context, a custom Dockerfile location
(just a shortcut for the common `-f <path>` args), or a bag of args, which
may include anything that the Docker build command itself supports.

Fixes https://github.com/pulumi/pulumi-cloud/issues/359.

(cherry picked from commit 9a1fbd78f10b99dc2e77e2041dd8d2106a2e5b6b)