### PR TITLE
Fix provider load failure error reporting

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -19,11 +19,16 @@ function loadFrameworkModule() {
     pulumi.log.debug(`Loading ${frameworkModule} for current environment.`);
     try {
         return require(frameworkModule);
-    } catch {
-        throw new Error(`
-Attempted to load the '${provider}' implementation of '@pulumi/cloud', but no ${frameworkModule} module is \
-installed. Install it now or select another provider implementation with the "cloud:config:provider" setting.`,
-        );
+    } catch (e) {
+        // If the module was not found, return a useful error message.
+        if ((e instanceof Error) && (e as any).code === "MODULE_NOT_FOUND") {
+            throw new Error(`
+Attempted to load the '${provider}' implementation of '@pulumi/cloud', but no '${frameworkModule}' module is installed.\
+ Install it now or select another provider implementation with the "cloud:config:provider" setting.`,
+            );
+        }
+        // Else, just return the error as is.
+        throw e;
     }
 }
 


### PR DESCRIPTION
We added the ability to provide a useful error message when a provider implementation of `@pulumi/cloud` failed to load.  However, there are legitimate errors that can occur during this load - for example, if AWS region config is not set, the `cloud-aws` module load will fail with an error.

Instead, only specially handle errors with `code === MODULE_NOT_FOUND` which indicates that Node.js failed to find the module.