### PR TITLE
Update package.json dependencies to match Gopkg.toml dependencies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,6 @@
         "typescript": "^2.6.2"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-23-g444ebdd1"
+        "@pulumi/pulumi": "^0.11.0-dev-155-g446d419c"
     }
 }

--- a/aws/package.json
+++ b/aws/package.json
@@ -24,6 +24,6 @@
     "peerDependencies": {
         "@pulumi/aws": "^0.11.0-dev-6-g124dd9c",
         "@pulumi/cloud": "${VERSION}",
-        "@pulumi/pulumi": "^0.11.0-dev-23-g444ebdd1"
+        "@pulumi/pulumi": "^0.11.0-dev-155-g446d419c"
     }
 }

--- a/mock/package.json
+++ b/mock/package.json
@@ -18,7 +18,7 @@
         "http-proxy-middleware": "^0.17.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-23-g444ebdd1",
+        "@pulumi/pulumi": "^0.11.0-dev-155-g446d419c",
         "@pulumi/cloud": "${VERSION}"
     }
 }


### PR DESCRIPTION
I think this is causing some of the pain in `pulumi/home`; this version of `@pulumi/pulumi` is pretty old now.