### PR TITLE
Avoid unnecessary data source calls

### DIFF
--- a/aws/infrastructure/aws.ts
+++ b/aws/infrastructure/aws.ts
@@ -4,22 +4,13 @@
 
 import * as aws from "@pulumi/aws";
 
-async function getAwsAccountId() {
-    const callerIdentity = await aws.getCallerIdentity();
-    return callerIdentity.accountId;
-}
-
-export let awsAccountId = getAwsAccountId();
-
-async function getAwsRegion() {
-    const region = await aws.getRegion({ current: true });
-    return region.name;
-}
-
-export let awsRegion = getAwsRegion();
+// Copmute the availability zones only once, and store the resulting promise.
+let azs: Promise<aws.GetAvailabilityZonesResult> | undefined;
 
 // Export as a function instead of a variable so clients can pass one AZ as a promise to a resource.
 export async function getAwsAz(index: number) {
-    const azs = await aws.getAvailabilityZones();
-    return azs.names[index];
+    if (!azs) {
+        azs = aws.getAvailabilityZones();
+    }
+    return (await azs).names[index];
 }

--- a/aws/infrastructure/cluster.ts
+++ b/aws/infrastructure/cluster.ts
@@ -2,12 +2,9 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { RunError } from "@pulumi/pulumi/errors";
 
-import { awsAccountId, awsRegion } from "./aws";
 import { Network } from "./network";
 
-import * as config from "../config";
 import { liftResource, sha1hash } from "../utils";
 
 // The default path to use for mounting EFS inside ECS container instances.
@@ -102,7 +99,7 @@ export class Cluster {
 
     constructor(name: string, args: ClusterArgs) {
         if (!args.network) {
-            throw new RunError("Expected a valid Network to use for creating Cluster");
+            throw new pulumi.RunError("Expected a valid Network to use for creating Cluster");
         }
 
         // First create an ECS cluster.


### PR DESCRIPTION
We were pre-computing a few pieces of information we don't use.  This was also causing a deprecation warning for something we didn't need.

Fixes #432.