### PR TITLE
Update pulumi-aws

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -502,7 +502,7 @@
 [[projects]]
   name = "github.com/pulumi/pulumi-aws"
   packages = ["."]
-  revision = "b7e10bc410eee37a1003a2b015c11f07f4f93a5c"
+  revision = "224edf8829facc4fb63ed8e520fe5bcf4e0607ec"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -705,6 +705,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "63330a5cc6c95303f292b17ad091d64e4c9bdd488459ef181df14fd764931a98"
+  inputs-digest = "bbd6c58e92c0313c67df95a2cd635fe2a9cd85497a449b1c0934dc65681df837"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,7 +6,7 @@ required = ["github.com/pulumi/pulumi-aws"]
 
 [[override]]
   name = "github.com/pulumi/pulumi-aws"
-  revision = "b7e10bc410eee37a1003a2b015c11f07f4f93a5c"
+  revision = "224edf8829facc4fb63ed8e520fe5bcf4e0607ec"
 
 [[constraint]]
   name = "github.com/stretchr/testify"


### PR DESCRIPTION
Release notes:

> When waiting for an ECS service to reach steady state, retry when ECS says the service can't be found. We can hit this when the ECS API performs a stale read of its datastore.