### PR TITLE
No longer pass `serialize` to aws.serverless.Function

### DIFF
--- a/aws/function.ts
+++ b/aws/function.ts
@@ -19,8 +19,7 @@ export class Function extends pulumi.ComponentResource {
 
     constructor(name: string,
                 handler: aws.serverless.Handler,
-                opts?: pulumi.ResourceOptions,
-                serialize?: (o: any) => boolean) {
+                opts?: pulumi.ResourceOptions) {
         super("cloud:function:Function", name, { handler: handler }, opts);
 
         // First allocate a function.
@@ -41,7 +40,7 @@ export class Function extends pulumi.ComponentResource {
                 subnetIds: pulumi.all(network.subnetIds),
             };
         }
-        this.lambda = new aws.serverless.Function(name, options, handler, { parent: this }, serialize).lambda;
+        this.lambda = new aws.serverless.Function(name, options, handler, { parent: this }).lambda;
 
         // And then a log group and subscription filter for that lambda.
         const _ = new aws.cloudwatch.LogSubscriptionFilter(name, {

--- a/aws/sns.ts
+++ b/aws/sns.ts
@@ -47,8 +47,6 @@ export function createSubscription(
             .then(() => { cb(null, null); })
             .catch((err: any) => { cb(err, null); });
         },
-        undefined,
-        o => o !== subscription,
     );
     const invokePermission = new aws.lambda.Permission(resName, {
         action: "lambda:invokeFunction",


### PR DESCRIPTION
We believe we should not need this after previous changes to closure serialization.