### PR TITLE
Publishing Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,20 @@ PROJECT_NAME := Pulumi Cloud Platform
 SUB_PROJECTS := api mock aws examples/integration
 include build/common.mk
 
-.PHONY: publish
-publish:
+
+.PHONY: publish_tgz
+publish_tgz:
 	$(call STEP_MESSAGE)
-	./scripts/publish.sh
+	./scripts/publish_tgz.sh
+
+.PHONY: publish_packages
+publish_packages:
+	$(call STEP_MESSAGE)
+	./scripts/publish_packages.sh
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: only_build publish only_test
+travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# publish_tgz.sh builds and publishes tarballs for a release
+set -o nounset -o errexit -o pipefail
+
+ROOT=$(dirname $0)/..
+PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
+PUBLISH_GOOS=("linux" "windows" "darwin")
+PUBLISH_GOARCH=("amd64")
+PUBLISH_PROJECT="pulumi-cloud"
+
+if [ ! -f $PUBLISH ]; then
+    >&2 echo "error: Missing publish script at $PUBLISH"
+    exit 1
+fi
+
+echo "Publishing SDK build to s3://eng.pulumi.com/:"
+for OS in "${PUBLISH_GOOS[@]}"
+do
+    for ARCH in "${PUBLISH_GOARCH[@]}"
+    do
+        export GOOS=${OS}
+        export GOARCH=${ARCH}
+
+        RELEASE_INFO=($($(dirname $0)/make_release.sh))
+        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
+    done
+done


### PR DESCRIPTION
1. Don't publish NPM and PyPI packages until after the tests have
passed. This means we won't publish untested packages and when tests
fail we can re-try the Travis job if we'd like, without NPM erroring
out because a package has already been published.

2. Adopt the changes in pulumi/pulumi to not tag pre-release builds
with the "latest" tag on NPM.