### PR TITLE
Use subnets instead of subnetMappings on LoadBalancer

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -130,7 +130,7 @@ function createLoadBalancer(
 
     const loadBalancer = new aws.elasticloadbalancingv2.LoadBalancer(shortName, {
         loadBalancerType: useAppLoadBalancer ? "application" : "network",
-        subnetMappings: network.publicSubnetIds.map(s => ({ subnetId: s })),
+        subnets: network.publicSubnetIds,
         internal: internal,
         // If this is an application LB, we need to associate it with the ECS cluster's security group, so
         // that traffic on any ports can reach it.  Otherwise, leave blank, and default to the VPC's group.


### PR DESCRIPTION
The `subnetMappings` property does not correctly handle changes, but the `subnets` property does - and supports the same use cases we need.

Workaround for pulumi/pulumi-terraform#45.

**ChangeLog**
A change to how load balancers are configured for `cloud.Service` will mean that applications may see load balancers for non-HTTP services get replaced during updates.  This should not cause disruption to applications, but may change the DNS names of the load balancers that services are exposed at.