### PR TITLE
Update dependencies to latest pulumi{-aws}

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,6 @@
         "typescript": "^2.6.2"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4"
+        "@pulumi/pulumi": "^0.11.1-dev-1523390330-g479a2e6a"
     }
 }

--- a/aws/examples/cluster/package.json
+++ b/aws/examples/cluster/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest"
     }

--- a/aws/examples/customDomain/package.json
+++ b/aws/examples/customDomain/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/aws": "^0.11.2",
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest"
     }

--- a/aws/package.json
+++ b/aws/package.json
@@ -22,8 +22,8 @@
         "typescript": "^2.6.2"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^0.11.0-dev-37-g399d60c",
+        "@pulumi/aws": "^0.11.1-dev-1523150138-g0d75d81",
         "@pulumi/cloud": "${VERSION}",
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4"
+        "@pulumi/pulumi": "^0.11.1-dev-1523390330-g479a2e6a"
     }
 }

--- a/aws/tests/performance/package.json
+++ b/aws/tests/performance/package.json
@@ -15,7 +15,7 @@
         "debug": "^3.1.0"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/aws/tests/unit/package.json
+++ b/aws/tests/unit/package.json
@@ -17,7 +17,7 @@
         "supertest": "^3.0.0"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/aws/tests/unit/variants/update1/package.json
+++ b/aws/tests/unit/variants/update1/package.json
@@ -19,6 +19,6 @@
     "peerDependencies": {
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest",
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4"
+        "@pulumi/pulumi": "^0.11.2"
     }
 }

--- a/aws/tests/unit/variants/update2/package.json
+++ b/aws/tests/unit/variants/update2/package.json
@@ -17,7 +17,7 @@
         "supertest": "^3.0.0"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest"
     }

--- a/examples/containers/package.json
+++ b/examples/containers/package.json
@@ -16,7 +16,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/countdown/package.json
+++ b/examples/countdown/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/httpEndpoint/package.json
+++ b/examples/httpEndpoint/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/httpEndpoint/variants/updateGetEndpoint/package.json
+++ b/examples/httpEndpoint/variants/updateGetEndpoint/package.json
@@ -13,7 +13,7 @@
         "@types/node": "^8.0.26"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -19,7 +19,7 @@
         "tslint": "^5.7.0"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/timers/package.json
+++ b/examples/timers/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -11,7 +11,7 @@
         "typescript": "^2.1.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/mock/package.json
+++ b/mock/package.json
@@ -18,7 +18,7 @@
         "http-proxy-middleware": "^0.17.4"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "${VERSION}"
     }
 }

--- a/mock/tests/httpEndpoint/package.json
+++ b/mock/tests/httpEndpoint/package.json
@@ -22,7 +22,7 @@
         "typescript": "^2.5.2"
     },
     "peerDependencies": {
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4",
+        "@pulumi/pulumi": "^0.11.2",
         "@pulumi/cloud": "latest"
     }
 }

--- a/mock/tests/table/package.json
+++ b/mock/tests/table/package.json
@@ -21,6 +21,6 @@
     },
     "peerDependencies": {
         "@pulumi/cloud": "latest",
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4"
+        "@pulumi/pulumi": "^0.11.2"
     }
 }

--- a/mock/tests/topic/package.json
+++ b/mock/tests/topic/package.json
@@ -21,6 +21,6 @@
     },
     "peerDependencies": {
         "@pulumi/cloud": "latest",
-        "@pulumi/pulumi": "^0.11.0-dev-130-g96d4cca4"
+        "@pulumi/pulumi": "^0.11.2"
     }
 }


### PR DESCRIPTION
We recently took a dependency on a breaking change in @pulumi/pulumi, but did not update our dependency.  This was okay in Travis because we still use `link` there - but fails when this package is used via NPM.

This change updates our dependencies for `api` and `aws` packages, and moves all examples to a more generic version specification.

Note that the `0.11.1-dev` versions mentioned here are actually *newer* than the `0.11.2` builds and contain the fixes (well - the breaking change), and so this change to try to require these newer builds may not actually work.

Attempt to unblock failure at https://travis-ci.com/pulumi/home/builds/70504239.