### PR TITLE
Use newer way of naming configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Pulumi's framework for building modern cloud applications.
 - [cloud] Support for `build` mode on `Container`, allowing container images to be built during deployment and
   automatically pushed to a remote repository used for the `Service` or `Task`.
 - [cloud-aws] Support for running compute (functions and containers) inside a private network via
-  `cloud-aws:config:usePrivateNetwork` config variable.
+  `cloud-aws:usePrivateNetwork` config variable.
 - [cloud-aws] The memory used for AWS Lambda Functions can be globally configured via the
-  `cloud-aws:config:functionMemorySize` config variable.
+  `cloud-aws:functionMemorySize` config variable.
 - [cloud-aws] Support for auto-creating a cluster to use for containers (`Service` and `Task`), via the
-  `cloud-aws:config:ecsAutoCluster` config variable.
+  `cloud-aws:ecsAutoCluster` config variable.
 - [cloud] Allow `Service` ports to specify a `protocol`, which may be `tcp` (default), `http` or `https`.  The later two
   will use Layer 7 load balancer, and `https` will additionally to SSL termination using globally configured SSL
   certificate information if available.

--- a/api/index.ts
+++ b/api/index.ts
@@ -25,7 +25,7 @@ function loadFrameworkModule() {
         if ((e instanceof Error) && (e as any).code === "MODULE_NOT_FOUND") {
             throw new RunError(`
 Attempted to load the '${provider}' implementation of '@pulumi/cloud', but no '${frameworkModule}' module is installed.\
- Install it now or select another provider implementation with the "cloud:config:provider" setting.`,
+ Install it now or select another provider implementation with the "cloud:provider" setting.`,
             );
         }
         // Else, just return the error as is.

--- a/aws/config/index.ts
+++ b/aws/config/index.ts
@@ -84,8 +84,8 @@ if (externalSecurityGroupsString) {
 
 if (externalVpcId && (!externalSubnets || !externalSecurityGroups)) {
     throw new RunError(
-        "Must configure 'cloud-aws:config:externalSubnets' and 'cloud-aws:config:externalSecurityGroups' " +
-        "when setting 'cloud-asws:config:externalVpcId'",
+        "Must configure 'cloud-aws:externalSubnets' and 'cloud-aws:externalSecurityGroups' " +
+        "when setting 'cloud-asws:externalVpcId'",
     );
 }
 

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -591,8 +591,8 @@ export class Service extends pulumi.ComponentResource implements cloud.Service {
     constructor(name: string, args: cloud.ServiceArguments, opts?: pulumi.ResourceOptions) {
         const cluster: awsinfra.Cluster | undefined = getCluster();
         if (!cluster) {
-            throw new RunError("Cannot create 'Service'.  Missing cluster config 'cloud-aws:config:ecsClusterARN'" +
-                " or 'cloud-aws:config:ecsAutoCluster' or 'cloud-aws:config:useFargate'");
+            throw new RunError("Cannot create 'Service'.  Missing cluster config 'cloud-aws:ecsClusterARN'" +
+                " or 'cloud-aws:ecsAutoCluster' or 'cloud-aws:useFargate'");
         }
 
         const containers = args.containers;
@@ -807,8 +807,8 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
         const network = getOrCreateNetwork();
         const cluster: awsinfra.Cluster | undefined = getCluster();
         if (!cluster) {
-            throw new Error("Cannot create 'Task'.  Missing cluster config 'cloud-aws:config:ecsClusterARN'" +
-                " or 'cloud-aws:config:ecsAutoCluster' or 'cloud-aws:config:useFargate'");
+            throw new Error("Cannot create 'Task'.  Missing cluster config 'cloud-aws:ecsClusterARN'" +
+                " or 'cloud-aws:ecsAutoCluster' or 'cloud-aws:useFargate'");
         }
         this.cluster = cluster;
         this.taskDefinition = createTaskDefinition(this, name, { container: container }).task;

--- a/aws/tests/performance/Pulumi.yaml
+++ b/aws/tests/performance/Pulumi.yaml
@@ -1,4 +1,4 @@
 name: performance
 runtime: nodejs
 config:
-  aws:config:region: us-east-2
+  aws:region: us-east-2

--- a/examples/httpEndpoint/Pulumi.yaml
+++ b/examples/httpEndpoint/Pulumi.yaml
@@ -1,4 +1,4 @@
 name: httpEndpoint
 runtime: nodejs
 config:
-  aws:config:region: us-east-2
+  aws:region: us-east-2

--- a/examples/httpEndpoint/variants/updateGetEndpoint/Pulumi.yaml
+++ b/examples/httpEndpoint/variants/updateGetEndpoint/Pulumi.yaml
@@ -1,4 +1,4 @@
 name: httpEndpoint
 runtime: nodejs
 config:
-  aws:config:region: us-east-2
+  aws:region: us-east-2

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -4,4 +4,4 @@ A simple SaaS integation example.
 
 Configuration required:
 
-* `lumi config integration:config:twitterAccessToken AAAAAZAZA`
+* `pulumi config set integration:twitterAccessToken AAAAAZAZA`

--- a/mock/tests/httpEndpoint/httpEndpoint.ts
+++ b/mock/tests/httpEndpoint/httpEndpoint.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
-pulumi.runtime.setConfig("cloud:config:provider", "mock");
+pulumi.runtime.setConfig("cloud:provider", "mock");
 
 import * as cloud from "@pulumi/cloud";
 import * as assert from "assert";

--- a/mock/tests/table/table.ts
+++ b/mock/tests/table/table.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
-pulumi.runtime.setConfig("cloud:config:provider", "mock");
+pulumi.runtime.setConfig("cloud:provider", "mock");
 
 import * as cloud from "@pulumi/cloud";
 import * as assert from "assert";

--- a/mock/tests/tests_test.go
+++ b/mock/tests/tests_test.go
@@ -19,7 +19,7 @@ func Test_Examples(t *testing.T) {
 		{
 			Dir: path.Join(cwd, "./table"),
 			Config: map[string]string{
-				"cloud:config:provider": "mock",
+				"cloud:provider": "mock",
 			},
 			Dependencies: []string{
 				"@pulumi/pulumi",

--- a/mock/tests/topic/topic.ts
+++ b/mock/tests/topic/topic.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
-pulumi.runtime.setConfig("cloud:config:provider", "mock");
+pulumi.runtime.setConfig("cloud:provider", "mock");
 
 import * as cloud from "@pulumi/cloud";
 import * as assert from "assert";


### PR DESCRIPTION
We used to force the `:config:` token in a configuration key and when
we removed that requirement we did not update all examples (and error
messages!)