### PR TITLE
Remove peerDependency from cloud-aws

### DIFF
--- a/aws/package.json
+++ b/aws/package.json
@@ -22,8 +22,5 @@
         "@types/semver": "^5.4.0",
         "tslint": "^5.7.0",
         "typescript": "^2.6.2"
-    },
-    "peerDependencies": {
-        "@pulumi/cloud": "${VERSION}"
     }
 }


### PR DESCRIPTION
DO NOT MERGE.  Using this PR to test out removing peer dependency, but there may be TypeScript interactions that prevent this from working as intended.

The peerDependency is technically not needed.  It is only used for TypeScript typing.