### PR TITLE
Fix package publishing

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -35,5 +35,5 @@ publish() {
     popd
 }
 
-publish api @pulumi/pulumi
-publish aws @pulumi/pulumi @pulumi/aws
+publish api
+publish aws


### PR DESCRIPTION
We no longer list @pulumi/pulumi or @pulumi/aws as peerDependencies
that need to be promoted. Instead, we just use actual dependencies.