### PR TITLE
Provide a config option to opt out of waitForSteadyState on Services

### DIFF
--- a/api/service.ts
+++ b/api/service.ts
@@ -215,6 +215,12 @@ export interface ServiceArguments {
      * The properties of the host where this service can run.
      */
     host?: HostProperties;
+    /**
+     *
+     * Determines whether the service should wait to fully transition to a new steady state on creation and updates. If
+     * set to false, the service may complete its deployment before it is fully ready to be used. Defaults to 'true'.
+     */
+    waitForSteadyState?: boolean;
 }
 
 export interface Endpoint {

--- a/aws/config/index.ts
+++ b/aws/config/index.ts
@@ -166,10 +166,3 @@ export function setEcsCluster(cluster: aws.ecs.Cluster,
         ecsClusterEfsMountPath = efsMountPath;
     }
 }
-
-/**
- * Determines whether ECS Services should wait until they are fully transitioned to a new steady state on creation and
- * updates. If set to false, Services may complete their deployment before they are fully ready to be used. Defaults to
- * 'true'.
- */
-export let ecsWaitForSteadyState = config.getBoolean("ecsWaitForSteadyState") || true;

--- a/aws/function.ts
+++ b/aws/function.ts
@@ -28,7 +28,7 @@ export class Function extends pulumi.ComponentResource {
             const network = getOrCreateNetwork();
             // TODO[terraform-providers/terraform-provider-aws#1507]: Updates which cause existing Lambdas to need to
             //     add VPC access will currently fail due to an issue in the Terraform provider.
-            options.policies.push(aws.iam.AWSLambdaVPCAccessExecutionRole);
+            options.policies!.push(aws.iam.AWSLambdaVPCAccessExecutionRole);
             options.vpcConfig = {
                 securityGroupIds: pulumi.all(network.securityGroupIds),
                 subnetIds: pulumi.all(network.subnetIds),

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -655,7 +655,7 @@ export class Service extends pulumi.ComponentResource implements cloud.Service {
             cluster: cluster.ecsClusterARN,
             loadBalancers: loadBalancers,
             placementConstraints: placementConstraintsForHost(args.host),
-            waitForSteadyState: config.ecsWaitForSteadyState,
+            waitForSteadyState: args.waitForSteadyState === undefined ? true : args.waitForSteadyState,
             launchType: config.useFargate ? "FARGATE" : "EC2",
             networkConfiguration: {
                 assignPublicIp: config.useFargate && !network.usePrivateSubnets,

--- a/examples/containers/index.ts
+++ b/examples/containers/index.ts
@@ -116,6 +116,7 @@ let builtService = new cloud.Service("examples-nginx2", {
         },
     },
     replicas: 2,
+    waitForSteadyState: false,
 });
 
 // expose some APIs meant for testing purposes.


### PR DESCRIPTION
We changed to make waitForSteadyState the default, which is more correct,  but especially while we do not support parallelism, can lead to very long deployment times in projects with a lot of Services.

Adds back the ability to opt-out of waitForSteadyState, for users who want faster deployments and are willing to build waiting logic into their deploymnt process outside of Pulumi.

Fixes #485.