### PR TITLE
Disallow empty {preview,update} changes.

### DIFF
--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -63,9 +63,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				baseURL, ok := stackInfo.Outputs["url"].(string)
 				assert.True(t, ok, "expected a `url` output property of type string")
@@ -131,9 +128,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		},
 		{
 			Dir: path.Join(cwd, "../examples/countdown"),
@@ -146,9 +140,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				// Wait 6 minutes to give the timer a chance to fire and for Lambda logs to be collected
 				time.Sleep(6 * time.Minute)
@@ -178,9 +169,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				baseURL, ok := stackInfo.Outputs["url"].(string)
 				assert.True(t, ok, "expected a `url` output property of type string")
@@ -256,9 +244,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		},
 		{
 			Dir: path.Join(cwd, "../examples/api"),
@@ -270,9 +255,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				baseURL, ok := stackInfo.Outputs["url"].(string)
 				assert.True(t, ok, "expected a `url` output string property")
@@ -313,9 +295,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				hitUnitTestsEndpoint(t, stackInfo)
 			},
@@ -347,9 +326,6 @@ func Test_Examples(t *testing.T) {
 				"@pulumi/cloud",
 				"@pulumi/cloud-aws",
 			},
-			// #494: lambda tests are unexpectedly proposing and performing code changes
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges: true,
 			ExtraRuntimeValidation: containersRuntimeValidator(fargateRegion),
 		},
 		{


### PR DESCRIPTION
Now that the recent closure serialization context changes are in, I dont
think we should be seeing changes proposed during empty previews.