### PR TITLE
Add a simpler way to create container services

### DIFF
--- a/api/service.ts
+++ b/api/service.ts
@@ -237,7 +237,8 @@ export let HostPathVolume: HostPathVolumeConstructor; // tslint:disable-line
 
 /**
  * The arguments to construct a Service object. These arguments may include container information, for simple
- * single-container scenarios, or you may specify that information using the containers property.
+ * single-container scenarios, or you may specify that information using the containers property. If a single container
+ * is specified in-line, it is implicitly given the name "default".
  */
 export interface ServiceArguments extends Container {
     /**

--- a/api/service.ts
+++ b/api/service.ts
@@ -236,14 +236,14 @@ export interface HostPathVolumeConstructor {
 export let HostPathVolume: HostPathVolumeConstructor; // tslint:disable-line
 
 /**
- * The arguments to construct a Service object.
+ * The arguments to construct a Service object. These arguments may include container information, for simple
+ * single-container scenarios, or you may specify that information using the containers property.
  */
-export interface ServiceArguments {
+export interface ServiceArguments extends Container {
     /**
-     * The collection of containers that will be deployed as part of this
-     * Service.
+     * A collection of containers that will be deployed as part of this Service, if there are multiple.
      */
-    containers: Containers;
+    containers?: Containers;
     /**
      * The number of copies of this Service's containers to deploy and maintain
      * as part of the running service.  Defaults to `1`.

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -601,7 +601,20 @@ export class Service extends pulumi.ComponentResource implements cloud.Service {
                 " or 'cloud-aws:ecsAutoCluster' or 'cloud-aws:useFargate'");
         }
 
-        const containers = args.containers;
+        let containers: cloud.Containers;
+        if (args.image || args.build || args.function) {
+            if (args.containers) {
+                throw new Error(
+                    "Exactly one of image, build, function, or containers must be used, not multiple");
+            }
+            containers = { "default": args };
+        } else if (args.containers) {
+            containers = args.containers;
+        } else {
+            throw new Error(
+                "Missing one of image, build, function, or containers, specifying this service's containers");
+        }
+
         const replicas = args.replicas === undefined ? 1 : args.replicas;
         const ports: ExposedPorts = {};
 

--- a/examples/containers/index.ts
+++ b/examples/containers/index.ts
@@ -29,6 +29,16 @@ let nginx = new cloud.Service("examples-nginx", {
 
 export let nginxEndpoint: Output<cloud.Endpoint> = nginx.defaultEndpoint;
 
+// A simple NGINX service, scaled out over two containers, using a single container rather than a map.
+let simpleNginx = new cloud.Service("examples-simple-nginx", {
+    image: "nginx",
+    memory: 128,
+    ports: [{ port: 80 }],
+    replicas: 2,
+});
+
+export let simpleNginxEndpoint: Output<cloud.Endpoint> = simpleNginx.defaultEndpoint;
+
 let cachedNginx = new cloud.Service("examples-cached-nginx", {
     containers: {
         nginx: {


### PR DESCRIPTION
This change adds a simpler way to construct container services. The
cloud.Service abstraction permits multi-container services, however that
is a more advanced scenario than the simple case of just wanting to
stand up a single container. This unfortunately means you have to give
the container a name which is almost always repetetive with respect to
all the other names floating around.

For example, this

    let nginx = new cloud.Service("nginx", {
        containers: {
            nginx: {
                image: "nginx",
            },
        },
    });

simply becomes

    let nginx = new cloud.Service("nginx", {
        image: "nginx",
    });

The approach used simply lets the Container information to come in with
the ServiceArguments. If that is present, we simply create a container
map out of it, using "default" as the name. We don't support mixing.

Fixes #234.