### PR TITLE
Do not pass an undefined security group to ecs.Service.

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -675,6 +675,7 @@ export class Service extends pulumi.ComponentResource implements cloud.Service {
         }
 
         // Create the service.
+        const securityGroups = cluster.securityGroupId ? [ cluster.securityGroupId ] : [];
         this.ecsService = new aws.ecs.Service(name, {
             desiredCount: replicas,
             taskDefinition: taskDefinition.task.arn,
@@ -685,7 +686,7 @@ export class Service extends pulumi.ComponentResource implements cloud.Service {
             launchType: config.useFargate ? "FARGATE" : "EC2",
             networkConfiguration: {
                 assignPublicIp: config.useFargate && !network.usePrivateSubnets,
-                securityGroups: [ cluster.securityGroupId!],
+                securityGroups: securityGroups,
                 subnets: network.subnetIds,
             },
         }, { parent: this, dependsOn: serviceDependsOn });


### PR DESCRIPTION
If the security group is undefined, we will marshal it as `nil` when
sending it to the engine (and thereby the AWS resource provider). This
causes a crash in the resource provider when TF attempts to validate the
`nil` value.