### PR TITLE
Make test package versions valid semvers

### DIFF
--- a/aws/examples/customDomain/package.json
+++ b/aws/examples/customDomain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customdomain",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/aws/tests/unit/package.json
+++ b/aws/tests/unit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unittests",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/aws/tests/unit/variants/update1/package.json
+++ b/aws/tests/unit/variants/update1/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unittests",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/aws/tests/unit/variants/update2/package.json
+++ b/aws/tests/unit/variants/update2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unittests",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apiExample",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/api/variants/updateGetEndpoint/package.json
+++ b/examples/api/variants/updateGetEndpoint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "apiExample",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/containers/package.json
+++ b/examples/containers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "containers",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/countdown/package.json
+++ b/examples/countdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "countdown",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/crawler/package.json
+++ b/examples/crawler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "crawler",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/integration-examples",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/simplecontainers/package.json
+++ b/examples/simplecontainers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simplecontainers",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/timers/package.json
+++ b/examples/timers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "timer",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "todo",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",


### PR DESCRIPTION
NPM and some other packages (including read-package-json that
@pulumi/pulumi) uses require the version field to be a valid
semver. So ensure ours are.