### PR TITLE
Remove the 'shadowing' linting rule.

### DIFF
--- a/aws/service.ts
+++ b/aws/service.ts
@@ -274,8 +274,8 @@ function computeImageFromBuild(
     pulumi.log.debug(`Building container image at '${build}'`, repository);
     const { repositoryUrl, registryId } = repository;
 
-    return pulumi.all([repositoryUrl, registryId]).apply(([repoUrl, regId]) =>
-        computeImageFromBuildWorker(preEnv, build, imageName, repoUrl, regId, repository));
+    return pulumi.all([repositoryUrl, registryId]).apply(([repositoryUrl, registryId]) =>
+        computeImageFromBuildWorker(preEnv, build, imageName, repositoryUrl, registryId, repository));
 }
 
 function computeImageFromBuildWorker(
@@ -385,15 +385,15 @@ function computeContainerDefinitions(
 
             return pulumi.all([imageOptions, container.command, container.memory,
                                container.memoryReservation, logGroup.id, container.dockerLabels])
-                         .apply(([imageOpts, command, memory, memoryReservation, logGroupId, dockerLabels]) => {
+                         .apply(([imageOptions, command, memory, memoryReservation, logGroupId, dockerLabels]) => {
                 const keyValuePairs: { name: string, value: string }[] = [];
-                for (const key of Object.keys(imageOpts.environment)) {
-                    keyValuePairs.push({ name: key, value: imageOpts.environment[key] });
+                for (const key of Object.keys(imageOptions.environment)) {
+                    keyValuePairs.push({ name: key, value: imageOptions.environment[key] });
                 }
 
                 const containerDefinition: aws.ecs.ContainerDefinition = {
                     name: containerName,
-                    image: imageOpts.image,
+                    image: imageOptions.image,
                     command: command,
                     memory: memory,
                     memoryReservation: memoryReservation,

--- a/tslint.json
+++ b/tslint.json
@@ -57,7 +57,6 @@
         "no-internal-module": true,
         "no-parameter-properties": false,
         "no-require-imports": false,
-        "no-shadowed-variable": true,
         "no-string-literal": false,
         "no-switch-case-fall-through": true,
         "no-trailing-whitespace": true,


### PR DESCRIPTION
In general i do like this rule.  However:

1. i don't think it's ever actually caught anythign useful for me.  
2. it's actively annoying when dealing with the pulumi `Output+.apply` pattern.  Specifically, we often want to combine a lot of outputs, then work with the unwrapped values.  These unwrapped values *should* shadow the wrapper versions, and it would be nice to be able to just continue using the same name as the wrapped value for clarity.

What do you think @lukehoban ?