### PR TITLE
Add all API files to tsconfig

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -16,7 +16,13 @@
         "strictNullChecks": true
     },
     "files": [
+        "api.ts",
+        "bucket.ts",
         "index.ts",
+        "service.ts",
+        "table.ts",
+        "timer.ts",
+        "topic.ts",
         "types.ts"
     ]
 }


### PR DESCRIPTION
This is needed for documentation generation to correctly find all the exported APIs in @pulumi/cloud.