### PR TITLE
Add missing tsconfig files

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -18,6 +18,7 @@
     "files": [
         "api.ts",
         "bucket.ts",
+        "httpServer.ts",
         "index.ts",
         "service.ts",
         "table.ts",

--- a/aws/tsconfig.json
+++ b/aws/tsconfig.json
@@ -17,13 +17,15 @@
     "files": [
         "index.ts",
         "api.ts",
+        "bucket.ts",
         "function.ts",
+        "httpServer.ts",
+        "service.ts",
         "sns.ts",
         "table.ts",
         "timer.ts",
         "topic.ts",
-        "service.ts",
-        "utils.ts",
+        "shared.ts",
 
         "config/index.ts",
     ]


### PR DESCRIPTION
This shouldn't be necessary, but our doc generation tools leave out APIs defined in files that aren't explicitly included, so until we figure out why, let's be explicit about including everything in tsconfig.