### PR TITLE
Move to a common test harness so we can share tests between azure and AWS

### DIFF
--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package examples
+package azuretests
 
 import (
 	"encoding/json"

--- a/examples/examples_harness.go
+++ b/examples/examples_harness.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	// "crypto/rand"
+	// "encoding/hex"
+	// "encoding/json"
+	// "fmt"
+	// "io/ioutil"
+	// "net/http"
+	// "os"
+	"path"
+	// "strings"
+	"testing"
+	// "time"
+
+	// "github.com/stretchr/testify/assert"
+
+	// "github.com/pulumi/pulumi/pkg/operations"
+	// "github.com/pulumi/pulumi/pkg/resource"
+	// "github.com/pulumi/pulumi/pkg/resource/config"
+	// "github.com/pulumi/pulumi/pkg/resource/stack"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	// "github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+func RunExamples(t *testing.T, provider, examplesDir string, setConfigVars func(config map[string]string) map[string]string) {
+	examples := []integration.ProgramTestOptions{
+		{
+			Dir: path.Join(examplesDir, "crawler"),
+			Config: setConfigVars(map[string]string{
+				"cloud:provider": provider,
+			}),
+			Dependencies: []string{
+				"@pulumi/cloud",
+				"@pulumi/cloud-" + provider,
+			},
+		},
+	}
+
+	longExamples := []integration.ProgramTestOptions{}
+
+	// Only include the long examples on non-Short test runs
+	if !testing.Short() {
+		examples = append(examples, longExamples...)
+	}
+
+	for _, ex := range examples {
+		example := ex.With(integration.ProgramTestOptions{
+			ReportStats: integration.NewS3Reporter("us-west-2", "eng.pulumi.com", "testreports"),
+			Tracing:     "https://tracing.pulumi-engineering.com/collector/api/v1/spans",
+			// TODO[pulumi/pulumi#1900]: This should be the default value, every test we have causes some sort of
+			// change during a `pulumi refresh` for reasons outside our control.
+			ExpectRefreshChanges: true,
+		})
+
+		t.Run(example.Dir, func(t *testing.T) {
+			integration.ProgramTest(t, &example)
+		})
+	}
+}


### PR DESCRIPTION
Note: this is step one in a long process to make all/most tests shared across azure and AWS.  Upcoming steps include:

1. Moving these tests to use HttpServer from API so they can work across AWS/Azure.
2. Updating Azure to them call into this shared testing point.

This will happen one test at a time.  This PR, however, is just for validating that we could have a common point that at least one set of provider tests can call into.