### PR TITLE
Switch to using the 'dev' version of our dependencies.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,7 @@
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "types": "types.d.ts",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4-dev-1537844791-g431f5b34"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537844791-g431f5b34.tgz#2c3d79515be81ab910f817376d32e8db83783cd3"
+"@pulumi/pulumi@dev":
+  version "0.15.4-dev-1537898302-g5d34e380"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/aws/examples/customDomain/package.json
+++ b/aws/examples/customDomain/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.27",

--- a/aws/examples/express/package.json
+++ b/aws/examples/express/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "express": "^4.16.3"
     },
     "devDependencies": {

--- a/aws/package.json
+++ b/aws/package.json
@@ -11,10 +11,10 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.4-dev",
-        "@pulumi/aws": "^0.15.2-dev",
-        "@pulumi/aws-infra": "^0.15.2-dev",
-        "@pulumi/docker": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
+        "@pulumi/aws": "dev",
+        "@pulumi/aws-infra": "dev",
+        "@pulumi/docker": "dev",
         "aws-serverless-express": "^3.3.5",
         "mime": "^2.0.3",
         "semver": "^5.4.0"

--- a/aws/tests/unit/package.json
+++ b/aws/tests/unit/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "chai": "^4.1.2",
         "mocha": "^3.5.3",
         "supertest": "^3.0.0"

--- a/aws/tests/unit/variants/update1/package.json
+++ b/aws/tests/unit/variants/update1/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "chai": "^4.1.2",
         "mocha": "^3.5.3",
         "supertest": "^3.0.0"

--- a/aws/tests/unit/variants/update2/package.json
+++ b/aws/tests/unit/variants/update2/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "chai": "^4.1.2",
         "mocha": "^3.5.3",
         "supertest": "^3.0.0"

--- a/aws/yarn.lock
+++ b/aws/yarn.lock
@@ -45,32 +45,32 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws-infra@^0.15.2-dev":
+"@pulumi/aws-infra@dev":
   version "0.15.2-dev-1537646386-ge17c90a"
   resolved "https://registry.yarnpkg.com/@pulumi/aws-infra/-/aws-infra-0.15.2-dev-1537646386-ge17c90a.tgz#46cbbef672caaf10249f1aa3e2d5ce968bde7b80"
   dependencies:
     "@pulumi/aws" "^0.15.2-dev"
     "@pulumi/pulumi" "^0.15.4-dev"
 
-"@pulumi/aws@^0.15.2-dev":
-  version "0.15.2-dev-1537864160-g37e1f2c"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1537864160-g37e1f2c.tgz#398c8c403c80b9cb45af126739825b7a91a76167"
+"@pulumi/aws@^0.15.2-dev", "@pulumi/aws@dev":
+  version "0.15.2-dev-1537910355-g327c12d"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1537910355-g327c12d.tgz#e1c9c4301d5093f5188526c4b6f9e592cf6bb5c4"
   dependencies:
-    "@pulumi/pulumi" "^0.15.4-dev"
+    "@pulumi/pulumi" dev
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/docker@^0.15.3-dev":
+"@pulumi/docker@dev":
   version "0.15.3-dev-1537850514-g9d22095"
   resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.15.3-dev-1537850514-g9d22095.tgz#9857ca02398f4f4d2ba8d2186ac437018aefa05f"
   dependencies:
     "@pulumi/pulumi" "^0.15.4-dev"
     semver "^5.4.0"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4-dev-1537844791-g431f5b34"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537844791-g431f5b34.tgz#2c3d79515be81ab910f817376d32e8db83783cd3"
+"@pulumi/pulumi@^0.15.4-dev", "@pulumi/pulumi@dev":
+  version "0.15.4-dev-1537898302-g5d34e380"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -220,8 +220,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.321.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.321.0.tgz#9661db58f2d01e20722691efb6e33114ee8739c1"
+  version "2.322.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.322.0.tgz#d9245cbdab6134bc5967644fea85daa32fd03632"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"

--- a/examples/api/package.json
+++ b/examples/api/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/api/variants/updateGetEndpoint/package.json
+++ b/examples/api/variants/updateGetEndpoint/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "@types/node": "^8.0.26"
     },
     "devDependencies": {

--- a/examples/containers/package.json
+++ b/examples/containers/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "node-fetch": "^1.7.3",
         "redis": "^2.8.0"
     },

--- a/examples/countdown/package.json
+++ b/examples/countdown/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.27",

--- a/examples/crawler/package.json
+++ b/examples/crawler/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "cheerio": "^1.0.0-rc.2",
         "node-fetch": "^1.7.3",
         "express": "^4.16.3"

--- a/examples/httpServer/package.json
+++ b/examples/httpServer/package.json
@@ -8,10 +8,10 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/cloud": "^0.15.2-dev",
-        "@pulumi/cloud-aws": "^0.15.2-dev",
-        "@pulumi/cloud-azure": "^0.15.2-dev",
+        "@pulumi/pulumi": "dev",
+        "@pulumi/cloud": "dev",
+        "@pulumi/cloud-aws": "dev",
+        "@pulumi/cloud-azure": "dev",
         "express": "^4.16.3"
     },
     "devDependencies": {

--- a/examples/integration/package.json
+++ b/examples/integration/package.json
@@ -9,7 +9,7 @@
         "lint": "tslint -c ../tslint.json -p tsconfig.json"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "dev",
         "jsforce": "^1.8.0",
         "request": "^2.81.0",
         "request-promise-native": "^1.0.4",

--- a/examples/integration/yarn.lock
+++ b/examples/integration/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@^0.15.3-dev":
-  version "0.15.3-dev-1536980346-gd67e0424"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.3-dev-1536980346-gd67e0424.tgz#122e3f9b00b07f320b37f04845d5866a5c973f74"
+"@pulumi/pulumi@dev":
+  version "0.15.4-dev-1537898302-g5d34e380"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/examples/simplecontainers/package.json
+++ b/examples/simplecontainers/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.27"

--- a/examples/timers/package.json
+++ b/examples/timers/package.json
@@ -8,7 +8,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -8,10 +8,10 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/cloud": "^0.15.2-dev",
-        "@pulumi/cloud-aws": "^0.15.2-dev",
-        "@pulumi/cloud-azure": "^0.15.2-dev",
+        "@pulumi/pulumi": "dev",
+        "@pulumi/cloud": "dev",
+        "@pulumi/cloud-aws": "dev",
+        "@pulumi/cloud-azure": "dev",
         "body-parser": "^1.18.3",
         "json-cycle": "^1.3.0",
         "express": "^4.16.3"


### PR DESCRIPTION
This prevents us from having to continually update these version numbers everywhere as we update upstream libs. We will still need to replace these with the right non-dev values when we publish official versins. But we had to do that anyways even when we were saying things like ~0.15.4-dev.