### PR TITLE
Initial sketch of a cloud-layer approach to let consumers flexibly control their Lambdas/FunctionApps.

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import { Callback } from "./callback";
 import { Endpoint } from "./service";
 
 /**

--- a/api/api.ts
+++ b/api/api.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import { Callback } from "./callback";
 import { Endpoint } from "./service";
 
 /**

--- a/api/bucket.ts
+++ b/api/bucket.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import { Callback } from "./callback";
 
 /**
  * BucketHandlerArgs are the arguments passed to an [onPut] or [onDelete] handler.
@@ -35,7 +36,7 @@ export interface BucketHandlerArgs {
 /**
  * BucketHandler is the callback that handles an [onPut] or [onDelete] event.
  */
-export type BucketHandler = (args: BucketHandlerArgs) => Promise<void>;
+export type BucketHandler = Callback<(args: BucketHandlerArgs) => Promise<void>>;
 
 /**
  * BucketFilter specifies filters to apply to an [onPut] or [onDelete] subscription.
@@ -92,7 +93,7 @@ export interface Bucket {
     /**
      * Insert a blob into the bucket.
      *
-     * @param key The key to use for retreiving this blob later.
+     * @param key The key to use for retrieving this blob later.
      * @returns A promise for the success or failure of the put.
      */
     put(key: string, contents: Buffer): Promise<void>;

--- a/api/callback.ts
+++ b/api/callback.ts
@@ -1,0 +1,42 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ * A cloud.CallbackData represents the full data  Pulumi needs  to create an appropriate serverless
+ * callback at runtime. For example, all the data necessary to create an AWS Lambda, or an Azure
+ * FunctionApp. [cloud.CallbackData]s are generally accepted anywhere a normal JavaScript callback
+ * would be accepted so as to give clients the ability to flexibly control how that callback is
+ * translated into a serverless runtime function.
+ *
+ * This type cannot be simply instantiated from within [cloud/api].  Instead, the subtypes should be
+ * used from the specific cloud provider packages (i.e. [cloud/aws/AwsCallbackData],
+ * [cloud/azure/AzureCallbackData], etc.). These subtypes will be provider-specific and will give
+ * fine-grained control using provider-specific concepts and constructs.
+ */
+export interface CallbackData<T extends Function> {
+    /**
+     * The JavaScript function to make the cloud-specific serverless function out of.  Additional
+     * cloud-specific information will have to be provided along with this.
+     */
+    function: T;
+}
+
+/**
+ * Type for parameters that will be converted into serverless function (i.e. an AWS Lambda, Azure
+ * FunctionApp, or etc.).  Either a simple JavaScript function, or an object with the full amount of
+ * data to be converted into the final serverless function can be provided.
+ */
+export type Callback<T extends Function> = T | CallbackData<T>;

--- a/api/callback.ts
+++ b/api/callback.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
-
 /**
  * A cloud.CallbackData represents the full data  Pulumi needs  to create an appropriate serverless
  * callback at runtime. For example, all the data necessary to create an AWS Lambda, or an Azure

--- a/api/httpServer.ts
+++ b/api/httpServer.ts
@@ -14,11 +14,12 @@
 
 import * as pulumi from "@pulumi/pulumi";
 import * as http from "http";
+import { Callback } from "./callback";
 
 // Factory function for creating a requestListener function.  The returned function is the same
 // callback function that would be passed to http.createServer.  See:
 // https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener for more details.
-export type RequestListenerFactory = () => (req: http.IncomingMessage, res: http.ServerResponse) => void;
+export type RequestListenerFactory = Callback<() => (req: http.IncomingMessage, res: http.ServerResponse) => void>;
 
 export interface HttpServerConstructor {
     /**

--- a/api/timer.ts
+++ b/api/timer.ts
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import { Callback } from "./callback";
 
 /**
  * Action is a handler that performs an action in response to a timer firing.
  */
-export type Action = () => Promise<void>;
+export type Action = Callback<() => Promise<void>>;
 
 /**
  * IntervalRate describes the rate at which a timer will fire.

--- a/api/topic.ts
+++ b/api/topic.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import { Callback } from "./callback";
 
 export interface TopicConstructor {
     /**
@@ -26,31 +27,7 @@ export interface TopicConstructor {
 
 export let Topic: TopicConstructor; // tslint:disable-line
 
-/**
- * A Topic<T> is used to distribute work which will be run concurrently by any
- * susbcribed handlers.  Producers can [[publish]] to the topic, and consumers
- * can [[subscribe]] to be notified when new items are published.
- *
- * @param T The type of items published to the topic.
- */
-export interface Topic<T> extends Stream<T> {
-    /**
-     * Publish an item to this Topic.
-     *
-     * @param item The item to publish.
-     */
-    publish: (item: T) => Promise<void>;
-
-    /**
-     * Subscribe to items published to this topic.
-     *
-     * Each subscription receives all items published to the topic.
-     *
-     * @param name The name of the subscription.
-     * @param handler A callback to handle each item published to the topic.
-     */
-    subscribe(name: string, handler: (item: T) => Promise<void>): void;
-}
+export type StreamHandler<T> = Callback<(item: T) => Promise<void>>;
 
 /**
  * A Stream<T> provides access to listen to an (infinite) stream of items coming
@@ -72,5 +49,21 @@ export interface Stream<T> {
      * @param name The name of the subscription.
      * @param handler A callback to handle each item published to the stream.
      */
-    subscribe(name: string, handler: (item: T) => Promise<void>): void;
+    subscribe(name: string, handler: StreamHandler<T>): void;
+}
+
+/**
+ * A Topic<T> is used to distribute work which will be run concurrently by any
+ * subscribed handlers.  Producers can [[publish]] to the topic, and consumers
+ * can [[subscribe]] to be notified when new items are published.
+ *
+ * @param T The type of items published to the topic.
+ */
+export interface Topic<T> extends Stream<T> {
+    /**
+     * Publish an item to this Topic.
+     *
+     * @param item The item to publish.
+     */
+    publish: (item: T) => Promise<void>;
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -18,6 +18,7 @@
     "files": [
         "api.ts",
         "bucket.ts",
+        "callback.ts",
         "index.ts",
         "service.ts",
         "table.ts",

--- a/api/types.ts
+++ b/api/types.ts
@@ -15,6 +15,7 @@
 // types.ts is declared in package.json as: types: "types.ts'. As such, this becomes the file that
 // typescript itself uses to determine the shape of this module.
 
+export * from "./callback";
 export * from "./bucket";
 export * from "./api";
 export * from "./httpServer";

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -46,8 +46,8 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
 "@pulumi/pulumi@dev":
-  version "0.15.5-dev-1539190917-g6707accd"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.5-dev-1539190917-g6707accd.tgz#3cad41d14db35f7e656546cdf9404dba17701c54"
+  version "0.16.1-dev-1539367749-ga71db160"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539367749-ga71db160.tgz#b67f9e5f171e5498a675b0c902d14972020a96c7"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -692,8 +692,8 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -854,8 +854,8 @@ tsutils@^2.27.2:
     tslib "^1.8.1"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
 
 upath@^1.1.0:
   version "1.1.0"

--- a/aws/bucket.ts
+++ b/aws/bucket.ts
@@ -16,9 +16,9 @@ import * as aws from "@pulumi/aws";
 import * as cloud from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 
-import { AwsCallback, createCallbackFunction, getOrCreateAwsCallbackData } from "./callback";
+import * as callback from "./callback";
 
-export type BucketHandler = AwsCallback<(args: cloud.BucketHandlerArgs) => Promise<void>>;
+export type BucketHandler = callback.AwsCallback<(args: cloud.BucketHandlerArgs) => Promise<void>>;
 
 export class Bucket extends pulumi.ComponentResource implements cloud.Bucket {
     public bucket: aws.s3.Bucket;
@@ -93,7 +93,7 @@ export class Bucket extends pulumi.ComponentResource implements cloud.Bucket {
     }
 
     public addHandler(name: string, handler: BucketHandler, events: string[], filter?: cloud.BucketFilter) {
-        const data = getOrCreateAwsCallbackData(handler);
+        const data = callback.getOrCreateAwsCallbackData(handler);
         const handlerFunc = data.function;
 
         // Create the wrapper function that will convert from raw AWS S3 events to the form
@@ -117,7 +117,7 @@ export class Bucket extends pulumi.ComponentResource implements cloud.Bucket {
                 err => callback(err, undefined));
         };
 
-        const lambda = createCallbackFunction(name, eventHandler, data, { parent: this });
+        const lambda = callback.createCallbackFunction(name, eventHandler, data, { parent: this });
 
         // Register for the raw s3 events from the bucket.
         filter = filter || {};

--- a/aws/callback.ts
+++ b/aws/callback.ts
@@ -20,7 +20,9 @@ import { getComputeIAMRolePolicies, getOrCreateNetwork, runLambdaInVPC } from ".
 
 /**
  * AWS-specific data to create an AWS lambda out of a callback function.  Can be passed to any
- * functions in pulumi/cloud-aws that can take a cloud.Callback<T> argument.
+ * functions in pulumi/cloud-aws that can take a cloud.Callback<T> argument.  To create the same
+ * default AwsCallbackData Pulumi creates when given a simple JavaScript function, use
+ * [createCallbackData].
  */
 export interface AwsCallbackData<T extends Function> extends cloud.CallbackData<T>, aws.lambda.CallbackFunctionArgs<any, any> {
     /**
@@ -39,7 +41,7 @@ export interface AwsCallbackData<T extends Function> extends cloud.CallbackData<
  */
 export type AwsCallback<T extends Function> = T | AwsCallbackData<T>;
 
-function createDefaultCallbackData<T extends Function>(func: T): AwsCallbackData<T> {
+export function createCallbackData<T extends Function>(func: T): AwsCallbackData<T> {
     const policies = [...getComputeIAMRolePolicies()];
     let vpcConfig: aws.serverless.FunctionOptions["vpcConfig"] | undefined;
 
@@ -70,7 +72,6 @@ function createDefaultCallbackData<T extends Function>(func: T): AwsCallbackData
 }
 
 function createCallbackFunctionArgs<E, R>(data: AwsCallbackData<any>): aws.lambda.CallbackFunctionArgs<E, R> {
-
     const copy = {...data};
     delete copy.function;
     const args = <aws.lambda.CallbackFunctionArgs<E, R>>copy;
@@ -103,7 +104,7 @@ export function createCallbackFactoryFunction<E, R>(
 
 export function getOrCreateAwsCallbackData<T extends Function>(callback: AwsCallback<T>): AwsCallbackData<T> {
     if (callback instanceof Function) {
-        const data = createDefaultCallbackData(callback);
+        const data = createCallbackData(callback);
         return data;
     }
 

--- a/aws/callback.ts
+++ b/aws/callback.ts
@@ -24,15 +24,7 @@ import { getComputeIAMRolePolicies, getOrCreateNetwork, runLambdaInVPC } from ".
  * default AwsCallbackData Pulumi creates when given a simple JavaScript function, use
  * [createCallbackData].
  */
-export interface AwsCallbackData<T extends Function> extends cloud.CallbackData<T>, aws.lambda.CallbackFunctionArgs<any, any> {
-    /**
-     * Not used.  Provide [function] instead.
-     */
-    callback?: never;
-    /**
-     * Not used.  Provide [function] instead.
-     */
-    callbackFactory?: never;
+export interface AwsCallbackData<T extends Function> extends cloud.CallbackData<T>, aws.lambda.BaseCallbackFunctionArgs {
 }
 
 /**

--- a/aws/callback.ts
+++ b/aws/callback.ts
@@ -1,0 +1,112 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import * as cloud from "@pulumi/cloud";
+import * as pulumi from "@pulumi/pulumi";
+import { functionIncludePackages, functionIncludePaths, functionMemorySize } from "./config";
+import { getComputeIAMRolePolicies, getOrCreateNetwork, runLambdaInVPC } from "./shared";
+
+/**
+ * AWS-specific data to create an AWS lambda out of a callback function.  Can be passed to any
+ * functions in pulumi/cloud-aws that can take a cloud.Callback<T> argument.
+ */
+export interface AwsCallbackData<T extends Function> extends cloud.CallbackData<T>, aws.lambda.CallbackFunctionArgs<any, any> {
+    /**
+     * Not used.  Provide [function] instead.
+     */
+    callback?: never;
+    /**
+     * Not used.  Provide [function] instead.
+     */
+    callbackFactory?: never;
+}
+
+/**
+ * Type for parameters that will be converted into serverless function.  Either a simple JavaScript
+ * function, or an object with information necessary to create an AWS Lambda can be used.
+ */
+export type AwsCallback<T extends Function> = T | AwsCallbackData<T>;
+
+function createDefaultCallbackData<T extends Function>(func: T): AwsCallbackData<T> {
+    const policies = [...getComputeIAMRolePolicies()];
+    let vpcConfig: aws.serverless.FunctionOptions["vpcConfig"] | undefined;
+
+    if (runLambdaInVPC) {
+        const network = getOrCreateNetwork();
+        // TODO[terraform-providers/terraform-provider-aws#1507]: Updates which cause existing Lambdas to need to
+        //     add VPC access will currently fail due to an issue in the Terraform provider.
+        policies.push(aws.iam.AWSLambdaVPCAccessExecutionRole);
+        vpcConfig = {
+            securityGroupIds: pulumi.all(network.securityGroupIds),
+            subnetIds: pulumi.all(network.subnetIds),
+        };
+    }
+
+    // First allocate a function.
+    const args: AwsCallbackData<T> = {
+        function: func,
+        policies,
+        vpcConfig,
+        memorySize: functionMemorySize,
+        codePathOptions: {
+            extraIncludePaths: functionIncludePaths,
+            extraIncludePackages: functionIncludePackages,
+        },
+    };
+
+    return args;
+}
+
+function createCallbackFunctionArgs<E, R>(data: AwsCallbackData<any>): aws.lambda.CallbackFunctionArgs<E, R> {
+
+    const copy = {...data};
+    delete copy.function;
+    const args = <aws.lambda.CallbackFunctionArgs<E, R>>copy;
+    return args;
+}
+
+/**
+ * Creates an [aws.lambda.CallbackFunction] from the callback function and callback data provided.
+ * The callback function becomes the entry-point for the AWS lambda.  The callback data is used to
+ * provided specialized configuration of that lambda (for example, specifying the desired
+ * [memorySize]).
+ */
+export function createCallbackFunction<E, R>(
+        name: string, callback: aws.lambda.Callback<E, R>,
+        data: AwsCallbackData<any>, opts?: pulumi.ResourceOptions): aws.lambda.CallbackFunction<E, R> {
+
+    const args = createCallbackFunctionArgs(data);
+    args.callback = callback;
+    return new aws.lambda.CallbackFunction(name, args, opts);
+}
+
+export function createCallbackFactoryFunction<E, R>(
+        name: string, callbackFactory: aws.lambda.CallbackFactory<E, R>,
+        data: AwsCallbackData<any>, opts?: pulumi.ResourceOptions): aws.lambda.CallbackFunction<E, R> {
+
+    const args = createCallbackFunctionArgs(data);
+    args.callbackFactory = callbackFactory;
+    return new aws.lambda.CallbackFunction(name, args, opts);
+}
+
+export function getOrCreateAwsCallbackData<T extends Function>(callback: AwsCallback<T>): AwsCallbackData<T> {
+    if (callback instanceof Function) {
+        const data = createDefaultCallbackData(callback);
+        return data;
+    }
+
+    // Already in AwsCallbackData form.
+    return callback;
+}

--- a/aws/function.ts
+++ b/aws/function.ts
@@ -39,6 +39,8 @@ export class Function extends pulumi.ComponentResource {
                 opts?: pulumi.ResourceOptions) {
         super("cloud:function:Function", name, { handler: handler }, opts);
 
+        
+
         const policies = [...getComputeIAMRolePolicies()];
         let vpcConfig: aws.serverless.FunctionOptions["vpcConfig"] | undefined;
 

--- a/aws/httpServer.ts
+++ b/aws/httpServer.ts
@@ -14,6 +14,8 @@
 
 // tslint:disable:max-line-length
 
+import * as http from "http";
+
 import * as aws from "@pulumi/aws";
 import { x } from "@pulumi/aws/apigateway";
 import * as lambda from "@pulumi/aws/lambda";
@@ -24,12 +26,14 @@ import * as callback from "./callback";
 
 import * as serverlessExpress from "aws-serverless-express";
 
+export type RequestListenerFactory = callback.AwsCallback<() => (req: http.IncomingMessage, res: http.ServerResponse) => void>;
+
 export class HttpServer extends pulumi.ComponentResource implements cloud.HttpServer {
     public /*out*/ readonly url: pulumi.Output<string>; // the URL for this deployment.
 
     public constructor(
         name: string,
-        createRequestListener: cloud.RequestListenerFactory,
+        createRequestListener: RequestListenerFactory,
         opts: pulumi.ComponentResourceOptions) {
 
         super("cloud:httpserver:HttpServer", name, {}, opts);

--- a/aws/httpServer.ts
+++ b/aws/httpServer.ts
@@ -20,7 +20,7 @@ import * as lambda from "@pulumi/aws/lambda";
 import * as cloud from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 
-import { createCallbackFactoryFunction, getOrCreateAwsCallbackData } from "./callback";
+import * as callback from "./callback";
 
 import * as serverlessExpress from "aws-serverless-express";
 
@@ -34,7 +34,7 @@ export class HttpServer extends pulumi.ComponentResource implements cloud.HttpSe
 
         super("cloud:httpserver:HttpServer", name, {}, opts);
 
-        const callbackData = getOrCreateAwsCallbackData(createRequestListener);
+        const callbackData = callback.getOrCreateAwsCallbackData(createRequestListener);
         const factoryFunction = callbackData.function;
 
         // Create the main aws lambda entry-point factory function.  Note that this is a factory
@@ -55,7 +55,7 @@ export class HttpServer extends pulumi.ComponentResource implements cloud.HttpSe
         };
 
         // Now, create the actual AWS lambda from that factory function.
-        const lambda = createCallbackFactoryFunction(name, entryPointFactory, callbackData, { parent: this });
+        const lambda = callback.createCallbackFactoryFunction(name, entryPointFactory, callbackData, { parent: this });
 
         const api = new aws.apigateway.x.API(name, {
             // Register two paths in the Swagger spec, for the root and for a catch all under the

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -20,7 +20,7 @@
 // actually exports the API types.
 
 export * from "./bucket";
-export { AwsCallbackData } from "./callback";
+export { AwsCallback, AwsCallbackData, createCallbackData } from "./callback";
 export * from "./function";
 export * from "./api";
 export * from "./httpServer";

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -20,6 +20,7 @@
 // actually exports the API types.
 
 export * from "./bucket";
+export { AwsCallbackData } from "./callback";
 export * from "./function";
 export * from "./api";
 export * from "./httpServer";

--- a/aws/timer.ts
+++ b/aws/timer.ts
@@ -50,6 +50,8 @@ export function cron(name: string, cronTab: string, handler: Action,
     createScheduledEvent(name, `cron(${cronTab})`, handler, opts);
 }
 
+export function daily(name: string, handler: Action, opts?: pulumi.ResourceOptions): void;
+export function daily(name: string, schedule: timer.DailySchedule, handler: Action, opts?: pulumi.ResourceOptions): void;
 export function daily(name: string,
                       scheduleOrHandler: timer.DailySchedule | Action,
                       handlerOrOptions?: Action | pulumi.ResourceOptions,
@@ -78,6 +80,8 @@ function isAction(val: any): val is Action {
     return val instanceof Function || !!(<callback.AwsCallbackData<any>>val).function;
 }
 
+export function hourly(name: string, handler: Action, opts?: pulumi.ResourceOptions): void;
+export function hourly(name: string, schedule: timer.HourlySchedule, handler: Action, opts?: pulumi.ResourceOptions): void;
 export function hourly(name: string,
                        scheduleOrHandler: timer.HourlySchedule | Action,
                        handlerOrOptions?: Action | pulumi.ResourceOptions,

--- a/aws/timer.ts
+++ b/aws/timer.ts
@@ -17,9 +17,9 @@ import { CallbackData, timer } from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 import { RunError } from "@pulumi/pulumi/errors";
 
-import { AwsCallback, createCallbackFunction, getOrCreateAwsCallbackData } from "./callback";
+import * as callback from "./callback";
 
-export type Action = AwsCallback<() => Promise<void>>;
+export type Action = callback.AwsCallback<() => Promise<void>>;
 
 export function interval(name: string, options: timer.IntervalRate, handler: Action,
                          opts?: pulumi.ResourceOptions): void {
@@ -112,10 +112,10 @@ class Timer extends pulumi.ComponentResource {
 
         this.scheduleExpression = scheduleExpression;
 
-        const data = getOrCreateAwsCallbackData(handler);
+        const data = callback.getOrCreateAwsCallbackData(handler);
         const handlerFunc = data.function;
 
-        this.function = createCallbackFunction(
+        this.function = callback.createCallbackFunction(
             name,
             (ev: any, ctx: aws.serverless.Context, cb: (error: any, result: any) => void) => {
                 handlerFunc().then(

--- a/aws/timer.ts
+++ b/aws/timer.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as aws from "@pulumi/aws";
-import { CallbackData, timer } from "@pulumi/cloud";
+import { timer } from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 import { RunError } from "@pulumi/pulumi/errors";
 
@@ -57,7 +57,7 @@ export function daily(name: string,
     let hour: number;
     let minute: number;
     let handler: Action;
-    if (scheduleOrHandler instanceof Function || isCallbackData(scheduleOrHandler)) {
+    if (isAction(scheduleOrHandler)) {
         hour = 0;
         minute = 0;
         handler = scheduleOrHandler as Action;
@@ -74,8 +74,8 @@ export function daily(name: string,
     cron(name, `${minute} ${hour} * * ? *`, handler, opts);
 }
 
-function isCallbackData(val: any): val is CallbackData<any> {
-    return !!(<CallbackData<any>>val).function;
+function isAction(val: any): val is Action {
+    return val instanceof Function || !!(<callback.AwsCallbackData<any>>val).function;
 }
 
 export function hourly(name: string,
@@ -84,7 +84,7 @@ export function hourly(name: string,
                        opts?: pulumi.ResourceOptions): void {
     let minute: number;
     let handler: Action;
-    if (scheduleOrHandler instanceof Function || isCallbackData(scheduleOrHandler)) {
+    if (isAction(scheduleOrHandler)) {
         minute = 0;
         handler = scheduleOrHandler as Action;
         opts = handlerOrOptions as pulumi.ResourceOptions | undefined;

--- a/aws/topic.ts
+++ b/aws/topic.ts
@@ -16,9 +16,9 @@ import * as aws from "@pulumi/aws";
 import * as cloud from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 
-import { AwsCallback, createCallbackFunction, getOrCreateAwsCallbackData } from "./callback";
+import * as callback from "./callback";
 
-export type StreamHandler<T> = AwsCallback<(item: T) => Promise<void>>;
+export type StreamHandler<T> = callback.AwsCallback<(item: T) => Promise<void>>;
 
 export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T> {
     private readonly name: string;
@@ -54,7 +54,7 @@ export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T>
     public subscribe(name: string, handler: StreamHandler<T>) {
         const subscriptionName = this.name + "_" + name;
 
-        const data = getOrCreateAwsCallbackData(handler);
+        const data = callback.getOrCreateAwsCallbackData(handler);
         const handlerFunc = data.function;
 
         const eventHandler: aws.sns.TopicEventHandler = (ev, context, callback) => {
@@ -63,7 +63,7 @@ export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T>
             })).then(() => callback(undefined, undefined), err => callback(err, undefined));
         };
 
-        const lambda = createCallbackFunction(subscriptionName, eventHandler, data, { parent: this });
+        const lambda = callback.createCallbackFunction(subscriptionName, eventHandler, data, { parent: this });
         this.topic.onEvent(subscriptionName, lambda, {}, { parent: this });
     }
 }

--- a/aws/tsconfig.json
+++ b/aws/tsconfig.json
@@ -17,6 +17,7 @@
     "files": [
         "index.ts",
         "api.ts",
+        "callback.ts",
         "function.ts",
         "table.ts",
         "timer.ts",

--- a/aws/yarn.lock
+++ b/aws/yarn.lock
@@ -53,8 +53,8 @@
     "@pulumi/pulumi" dev
 
 "@pulumi/aws@dev":
-  version "0.16.1-dev-1539413196-gf976692"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.1-dev-1539413196-gf976692.tgz#1db706ead8113bd4da82753d71ba25b0b8fb429a"
+  version "0.16.1-dev-1539712276-g0907029"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.1-dev-1539712276-g0907029.tgz#32a736b726d1795a229b39bd372885e1ace6c6ff"
   dependencies:
     "@pulumi/pulumi" dev
     builtin-modules "3.0.0"

--- a/aws/yarn.lock
+++ b/aws/yarn.lock
@@ -46,15 +46,15 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
 "@pulumi/aws-infra@dev":
-  version "0.15.2-dev-1537646386-ge17c90a"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws-infra/-/aws-infra-0.15.2-dev-1537646386-ge17c90a.tgz#46cbbef672caaf10249f1aa3e2d5ce968bde7b80"
+  version "0.15.2-dev-1539374157-g0b12426"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws-infra/-/aws-infra-0.15.2-dev-1539374157-g0b12426.tgz#5e2352a202915aba1eea9113fd343b43422547fe"
   dependencies:
-    "@pulumi/aws" "^0.15.2-dev"
-    "@pulumi/pulumi" "^0.15.4-dev"
+    "@pulumi/aws" dev
+    "@pulumi/pulumi" dev
 
-"@pulumi/aws@^0.15.2-dev", "@pulumi/aws@dev":
-  version "0.15.2-dev-1539195847-g9abeb1b"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1539195847-g9abeb1b.tgz#cd7210edb5bac4aa34968e8b2223f97ee44b13e9"
+"@pulumi/aws@dev":
+  version "0.16.1-dev-1539375013-g0030710"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.1-dev-1539375013-g0030710.tgz#37dab22dfb8b98927bd5d9cb14fe2640c2808c94"
   dependencies:
     "@pulumi/pulumi" dev
     builtin-modules "3.0.0"
@@ -63,30 +63,15 @@
     resolve "^1.7.1"
 
 "@pulumi/docker@dev":
-  version "0.15.3-dev-1537850514-g9d22095"
-  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.15.3-dev-1537850514-g9d22095.tgz#9857ca02398f4f4d2ba8d2186ac437018aefa05f"
+  version "0.16.1-dev-1539384558-g8716afc"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1539384558-g8716afc.tgz#60077959d8f3f0749e5f00cf99e888c0152e7381"
   dependencies:
-    "@pulumi/pulumi" "^0.15.4-dev"
+    "@pulumi/pulumi" dev
     semver "^5.4.0"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4.tgz#d4eb95d0b29fb092efa63f119cdd83661b694057"
-  dependencies:
-    google-protobuf "^3.5.0"
-    grpc "^1.12.2"
-    minimist "^1.2.0"
-    normalize-package-data "^2.4.0"
-    protobufjs "^6.8.6"
-    read-package-tree "^5.2.1"
-    require-from-string "^2.0.1"
-    source-map-support "^0.4.16"
-    ts-node "^7.0.0"
-    typescript "^3.0.0"
-
 "@pulumi/pulumi@dev":
-  version "0.15.5-dev-1539190917-g6707accd"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.5-dev-1539190917-g6707accd.tgz#3cad41d14db35f7e656546cdf9404dba17701c54"
+  version "0.16.1-dev-1539367749-ga71db160"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539367749-ga71db160.tgz#b67f9e5f171e5498a675b0c902d14972020a96c7"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -133,7 +118,7 @@
 
 "@types/events@*":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  resolved "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
 "@types/express-serve-static-core@*":
   version "4.16.0"
@@ -237,8 +222,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.331.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.331.0.tgz#39cf61040a33c2e4a576fe4d5ec15259a89f9bbe"
+  version "2.334.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.334.0.tgz#cf70be2f28f5350a882618a665c9703ad8a5e8c2"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -888,8 +873,8 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -1057,8 +1042,8 @@ type-is@^1.6.16:
     mime-types "~2.1.18"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
 
 upath@^1.1.0:
   version "1.1.0"

--- a/azure/bucket.ts
+++ b/azure/bucket.ts
@@ -116,12 +116,12 @@ export class Bucket extends pulumi.ComponentResource implements cloud.Bucket {
             const subscriptionArgs = callback.createCallbackEventSubscriptionArgs(entryPoint, data);
 
             serverless.storage.onBlobEvent(putName, storageAccount, {
-                ...subscriptionArgs,
-                storageAccount: storageAccount,
-                containerName: container.name,
-                filterPrefix: filter.keyPrefix,
-                filterSuffix: filter.keySuffix,
-            }, { parent: this });
+                    ...subscriptionArgs,
+                    storageAccount: storageAccount,
+                    containerName: container.name,
+                    filterPrefix: filter.keyPrefix,
+                    filterSuffix: filter.keySuffix,
+                }, { parent: this });
         };
 
         this.onDelete = async (delName, handler, filter) => {

--- a/azure/callback.ts
+++ b/azure/callback.ts
@@ -1,0 +1,109 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Callback, CallbackFactory, Context, EventSubscription, EventSubscriptionArgs } from "@pulumi/azure-serverless/subscription";
+import * as cloud from "@pulumi/cloud";
+import * as pulumi from "@pulumi/pulumi";
+import * as shared from "./shared";
+
+/**
+ * Azure-specific data to create an AWS lambda out of a callback function.  Can be passed to any
+ * functions in pulumi/cloud-aws that can take a cloud.Callback<T> argument.  To create the same
+ * default AwsCallbackData Pulumi creates when given a simple JavaScript function, use
+ * [createCallbackData].
+ */
+export interface AzureCallbackData<T extends Function> extends cloud.CallbackData<T>, EventSubscriptionArgs<any, any> {
+    /**
+     * Not used.  Provide [function] instead.
+     */
+    func?: never;
+    /**
+     * Not used.  Provide [function] instead.
+     */
+    factoryFunc?: never;
+}
+
+/**
+ * Type for parameters that will be converted into serverless function.  Either a simple JavaScript
+ * function, or an object with information necessary to create an AWS Lambda can be used.
+ */
+export type AzureCallback<T extends Function> = T | AzureCallbackData<T>;
+
+export function createCallbackData<T extends Function>(func: T): AzureCallbackData<T> {
+    const data: AzureCallbackData<T> = {
+        ...shared.defaultSubscriptionArgs,
+        function: func,
+    };
+
+    return data;
+}
+
+// function createEventSubscriptionArgs<E extends Context, R>(data: AzureCallback<any>): EventSubscriptionArgs<E, R> {
+//     const copy = {...data};
+//     delete copy.function;
+//     const args = <EventSubscriptionArgs<E, R>>copy;
+//     return args;
+// }
+
+export function createCallbackEventSubscriptionArgs<E extends Context, R>(
+        callback: Callback<E, R>, data: AzureCallback<any>): EventSubscriptionArgs<E, R> {
+    const copy = {...data};
+    delete copy.function;
+    const args = <EventSubscriptionArgs<E, R>>copy;
+    args.func = callback;
+    return args;
+}
+
+export function createCallbackFactoryEventSubscriptionArgs<E extends Context, R>(
+        callbackFactory: CallbackFactory<E, R>, data: AzureCallback<any>): EventSubscriptionArgs<E, R> {
+    const copy = {...data};
+    delete copy.function;
+    const args = <EventSubscriptionArgs<E, R>>copy;
+    args.factoryFunc = callbackFactory;
+    return args;
+}
+
+/**
+ * Creates an [aws.lambda.CallbackFunction] from the callback function and callback data provided.
+ * The callback function becomes the entry-point for the AWS lambda.  The callback data is used to
+ * provided specialized configuration of that lambda (for example, specifying the desired
+ * [memorySize]).
+ */
+// export function createEventSubscription<E extends Context, R>(
+//         name: string, callback: Callback<E, R>,
+//         data: AzureCallbackData<any>, opts?: pulumi.ResourceOptions): EventSubscription<E, R> {
+
+//     const args = createEventSubscriptionArgs(data);
+//     args.func = callback;
+//     return new EventSubscription<E, R>(.lambda.CallbackFunction(name, args, opts);
+// }
+
+// export function createCallbackFactoryFunction<E, R>(
+//         name: string, callbackFactory: aws.lambda.CallbackFactory<E, R>,
+//         data: AwsCallbackData<any>, opts?: pulumi.ResourceOptions): aws.lambda.CallbackFunction<E, R> {
+
+//     const args = createCallbackFunctionArgs(data);
+//     args.callbackFactory = callbackFactory;
+//     return new aws.lambda.CallbackFunction(name, args, opts);
+// }
+
+export function getOrCreateAzureCallbackData<T extends Function>(callback: AzureCallback<T>): AzureCallbackData<T> {
+    if (callback instanceof Function) {
+        const data = createCallbackData(callback);
+        return data;
+    }
+
+    // Already in AwsCallbackData form.
+    return callback;
+}

--- a/azure/callback.ts
+++ b/azure/callback.ts
@@ -18,9 +18,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as shared from "./shared";
 
 /**
- * Azure-specific data to create an AWS lambda out of a callback function.  Can be passed to any
+ * Azure-specific data to create an FunctionApp out of a callback function.  Can be passed to any
  * functions in pulumi/cloud-aws that can take a cloud.Callback<T> argument.  To create the same
- * default AwsCallbackData Pulumi creates when given a simple JavaScript function, use
+ * default AzureCallbackData Pulumi creates when given a simple JavaScript function, use
  * [createCallbackData].
  */
 export interface AzureCallbackData<T extends Function> extends cloud.CallbackData<T>, EventSubscriptionArgs<any, any> {
@@ -36,7 +36,7 @@ export interface AzureCallbackData<T extends Function> extends cloud.CallbackDat
 
 /**
  * Type for parameters that will be converted into serverless function.  Either a simple JavaScript
- * function, or an object with information necessary to create an AWS Lambda can be used.
+ * function, or an object with information necessary to create an Azure FunctionApp can be used.
  */
 export type AzureCallback<T extends Function> = T | AzureCallbackData<T>;
 
@@ -48,13 +48,6 @@ export function createCallbackData<T extends Function>(func: T): AzureCallbackDa
 
     return data;
 }
-
-// function createEventSubscriptionArgs<E extends Context, R>(data: AzureCallback<any>): EventSubscriptionArgs<E, R> {
-//     const copy = {...data};
-//     delete copy.function;
-//     const args = <EventSubscriptionArgs<E, R>>copy;
-//     return args;
-// }
 
 export function createCallbackEventSubscriptionArgs<E extends Context, R>(
         callback: Callback<E, R>, data: AzureCallback<any>): EventSubscriptionArgs<E, R> {
@@ -74,36 +67,12 @@ export function createCallbackFactoryEventSubscriptionArgs<E extends Context, R>
     return args;
 }
 
-/**
- * Creates an [aws.lambda.CallbackFunction] from the callback function and callback data provided.
- * The callback function becomes the entry-point for the AWS lambda.  The callback data is used to
- * provided specialized configuration of that lambda (for example, specifying the desired
- * [memorySize]).
- */
-// export function createEventSubscription<E extends Context, R>(
-//         name: string, callback: Callback<E, R>,
-//         data: AzureCallbackData<any>, opts?: pulumi.ResourceOptions): EventSubscription<E, R> {
-
-//     const args = createEventSubscriptionArgs(data);
-//     args.func = callback;
-//     return new EventSubscription<E, R>(.lambda.CallbackFunction(name, args, opts);
-// }
-
-// export function createCallbackFactoryFunction<E, R>(
-//         name: string, callbackFactory: aws.lambda.CallbackFactory<E, R>,
-//         data: AwsCallbackData<any>, opts?: pulumi.ResourceOptions): aws.lambda.CallbackFunction<E, R> {
-
-//     const args = createCallbackFunctionArgs(data);
-//     args.callbackFactory = callbackFactory;
-//     return new aws.lambda.CallbackFunction(name, args, opts);
-// }
-
 export function getOrCreateAzureCallbackData<T extends Function>(callback: AzureCallback<T>): AzureCallbackData<T> {
     if (callback instanceof Function) {
         const data = createCallbackData(callback);
         return data;
     }
 
-    // Already in AwsCallbackData form.
+    // Already in AzureCallbackData form.
     return callback;
 }

--- a/azure/index.ts
+++ b/azure/index.ts
@@ -43,6 +43,4 @@ import * as thisModule from "./index";
 let apiShape: typeof apiModule = undefined as any;
 const thisShape: typeof thisModule = undefined as any;
 
-// This line ensures that our exported API is a superset of the framework API. right now we can't
-// uncomment it because we provide more specific subtypes of certain cloud-api types at this level.
-// thisShape = frameworkShape;
+apiShape = thisShape;

--- a/azure/index.ts
+++ b/azure/index.ts
@@ -43,5 +43,6 @@ import * as thisModule from "./index";
 let apiShape: typeof apiModule = undefined as any;
 const thisShape: typeof thisModule = undefined as any;
 
-// This line ensures that our exported API is a superset of the framework API.
-apiShape = thisShape;
+// This line ensures that our exported API is a superset of the framework API. right now we can't
+// uncomment it because we provide more specific subtypes of certain cloud-api types at this level.
+// thisShape = frameworkShape;

--- a/azure/index.ts
+++ b/azure/index.ts
@@ -43,4 +43,5 @@ import * as thisModule from "./index";
 let apiShape: typeof apiModule = undefined as any;
 const thisShape: typeof thisModule = undefined as any;
 
+// This line ensures that our exported API is a superset of the framework API.
 apiShape = thisShape;

--- a/azure/timer.ts
+++ b/azure/timer.ts
@@ -105,6 +105,8 @@ function pad(val: number | undefined): string {
     return val.toString();
 }
 
+export function daily(name: string, handler: Action, opts?: pulumi.ResourceOptions): void;
+export function daily(name: string, schedule: timer.DailySchedule, handler: Action, opts?: pulumi.ResourceOptions): void;
 export function daily(name: string,
                       scheduleOrHandler: timer.DailySchedule | Action,
                       handlerOrOptions?: Action | pulumi.ResourceOptions,
@@ -129,6 +131,8 @@ export function daily(name: string,
     cron(name, `${minute} ${hour} * * ? *`, handler, opts);
 }
 
+export function hourly(name: string, handler: Action, opts?: pulumi.ResourceOptions): void;
+export function hourly(name: string, schedule: timer.HourlySchedule, handler: Action, opts?: pulumi.ResourceOptions): void;
 export function hourly(name: string,
                        scheduleOrHandler: timer.HourlySchedule | Action,
                        handlerOrOptions?: Action | pulumi.ResourceOptions,

--- a/azure/yarn.lock
+++ b/azure/yarn.lock
@@ -62,30 +62,15 @@
     "@pulumi/pulumi" dev
 
 "@pulumi/docker@dev":
-  version "0.15.3-dev-1537850514-g9d22095"
-  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.15.3-dev-1537850514-g9d22095.tgz#9857ca02398f4f4d2ba8d2186ac437018aefa05f"
+  version "0.16.1-dev-1539384558-g8716afc"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1539384558-g8716afc.tgz#60077959d8f3f0749e5f00cf99e888c0152e7381"
   dependencies:
-    "@pulumi/pulumi" "^0.15.4-dev"
+    "@pulumi/pulumi" dev
     semver "^5.4.0"
 
-"@pulumi/pulumi@^0.15.4-dev":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4.tgz#d4eb95d0b29fb092efa63f119cdd83661b694057"
-  dependencies:
-    google-protobuf "^3.5.0"
-    grpc "^1.12.2"
-    minimist "^1.2.0"
-    normalize-package-data "^2.4.0"
-    protobufjs "^6.8.6"
-    read-package-tree "^5.2.1"
-    require-from-string "^2.0.1"
-    source-map-support "^0.4.16"
-    ts-node "^7.0.0"
-    typescript "^3.0.0"
-
 "@pulumi/pulumi@dev":
-  version "0.15.5-dev-1539190917-g6707accd"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.5-dev-1539190917-g6707accd.tgz#3cad41d14db35f7e656546cdf9404dba17701c54"
+  version "0.16.1-dev-1539367749-ga71db160"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.1-dev-1539367749-ga71db160.tgz#b67f9e5f171e5498a675b0c902d14972020a96c7"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -132,7 +117,7 @@
 
 "@types/events@*":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  resolved "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
 "@types/express-serve-static-core@*":
   version "4.16.0"
@@ -389,20 +374,20 @@ binary-case@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/binary-case/-/binary-case-1.1.4.tgz#d687104d59e38f2b9e658d3a58936963c59ab931"
 
-body-parser@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
+body-parser@1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   dependencies:
     bytes "3.0.0"
     content-type "~1.0.4"
     debug "2.6.9"
-    depd "~1.1.1"
-    http-errors "~1.6.2"
-    iconv-lite "0.4.19"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
     on-finished "~2.3.0"
-    qs "6.5.1"
-    raw-body "2.3.2"
-    type-is "~1.6.15"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -581,11 +566,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
-depd@~1.1.1, depd@~1.1.2:
+depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -658,12 +639,12 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
 express@^4.16.3:
-  version "4.16.3"
-  resolved "http://registry.npmjs.org/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   dependencies:
     accepts "~1.3.5"
     array-flatten "1.1.1"
-    body-parser "1.18.2"
+    body-parser "1.18.3"
     content-disposition "0.5.2"
     content-type "~1.0.4"
     cookie "0.3.1"
@@ -680,10 +661,10 @@ express@^4.16.3:
     on-finished "~2.3.0"
     parseurl "~1.3.2"
     path-to-regexp "0.1.7"
-    proxy-addr "~2.0.3"
-    qs "6.5.1"
+    proxy-addr "~2.0.4"
+    qs "6.5.2"
     range-parser "~1.2.0"
-    safe-buffer "5.1.1"
+    safe-buffer "5.1.2"
     send "0.16.2"
     serve-static "1.13.2"
     setprototypeof "1.1.0"
@@ -841,16 +822,7 @@ hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-http-errors@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
-  dependencies:
-    depd "1.1.1"
-    inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
-
-http-errors@~1.6.2:
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
@@ -867,9 +839,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+iconv-lite@0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.4:
   version "0.4.24"
@@ -1306,7 +1280,7 @@ protobufjs@^6.8.6:
     "@types/node" "^10.1.0"
     long "^4.0.0"
 
-proxy-addr@~2.0.3:
+proxy-addr@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
   dependencies:
@@ -1321,11 +1295,7 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-qs@~6.5.2:
+qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -1333,13 +1303,13 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
   dependencies:
     bytes "3.0.0"
-    http-errors "1.6.2"
-    iconv-lite "0.4.19"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
     unpipe "1.0.0"
 
 rc@^1.2.7:
@@ -1445,11 +1415,7 @@ rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-safe-buffer@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -1470,8 +1436,8 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 send@0.16.2:
   version "0.16.2"
@@ -1503,10 +1469,6 @@ serve-static@1.13.2:
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -1568,21 +1530,20 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.1.tgz#b79a089a732e346c6e0714830f36285cd38191a2"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-    safer-buffer "^2.0.2"
-  optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
     ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
     jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+"statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
@@ -1726,7 +1687,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-type-is@^1.6.16, type-is@~1.6.15, type-is@~1.6.16:
+type-is@^1.6.16, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:
@@ -1734,8 +1695,8 @@ type-is@^1.6.16, type-is@~1.6.15, type-is@~1.6.16:
     mime-types "~2.1.18"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
 
 underscore@1.4.x:
   version "1.4.4"


### PR DESCRIPTION
This PR introduces a similar concept to the split we see in pulumi/aws, where 'callback' functions allow either a JavaScript callback, or a strait aws.lambda.Function to be passed in.

In this PR, we expand that out to the cloud layer in a non-cloud-neutral fashion.  Specifically, cloud apis that previously just allowed a callback JavaScript function now allow either:

1. a JavaScript callback function as before.
2. a CallbackData object that both has the callback function, and also allows cloud-specific Lambda/FunctionApp configuration values to be provided (like AWS roles, max memory size, policies, etc.)

Because this CallbackData object is inherently cloud-specific, all that is defined at the cloud-api layer is that it is an object that holds onto the JavaScript function.  At the individual cloud layers you can then create sub-types of this like AwsCallbackdata which contain the full rich set of Lambda configuration we already expose inside pulumi/aws.

--

Note: this is still a wip.  I have to do the Azure side as well.  But i'm sending out now to get some initial discussion going on this and to see if people have better ideas how we might do things.  

--

A core non-goal is to have a completely cloud-neutral way to specify cloud functions.  Right now, it's very hard to have anything useful as both clouds are so different.  The expectatoin here is also that people would likely not be trying to run their cloud apps on different clouds.  So, if they ran into a need to customize a Lambda/FunctionApp they could just create the suitable cloud specific information and effectively customize that way.