### PR TITLE
Deprecate the existing cloud.Function wrapper and use aws.lambda.CallbackFunction instead.

### DIFF
--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -46,8 +46,8 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
 "@pulumi/pulumi@dev":
-  version "0.16.3-dev-1540908796-g0ac0cae7"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1540908796-g0ac0cae7.tgz#6815af7ad7c865455561fd9eff2800227c2754ee"
+  version "0.16.3-dev-1541212326-gafd53915"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1541212326-gafd53915.tgz#6a15669039b1d4be7d2e709eac6f007532ee8921"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -66,12 +66,12 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
 "@types/node@^10.1.0":
-  version "10.12.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
+  version "10.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
 
 "@types/node@^8.0.26":
-  version "8.10.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.36.tgz#eac05d576fbcd0b4ea3c912dc58c20475c08d9e4"
+  version "8.10.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.37.tgz#d2db49dc6a4e087c3245f22b92061f22494771e5"
 
 abbrev@1:
   version "1.1.1"
@@ -316,12 +316,12 @@ google-protobuf@^3.5.0:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
 grpc@^1.12.2:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.15.1.tgz#046263d9b0c440c8e36fece03e227cb3afe28514"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"
   dependencies:
     lodash "^4.17.5"
     nan "^2.0.0"
@@ -747,8 +747,8 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -854,8 +854,8 @@ tsutils@^2.27.2:
     tslib "^1.8.1"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
 
 upath@^1.1.0:
   version "1.1.0"

--- a/aws/function.ts
+++ b/aws/function.ts
@@ -17,16 +17,6 @@ import * as pulumi from "@pulumi/pulumi";
 import { functionIncludePackages, functionIncludePaths, functionMemorySize } from "./config";
 import { getComputeIAMRolePolicies, getOrCreateNetwork, runLambdaInVPC } from "./shared";
 
-export function createFunction(
-        name: string, handler: aws.serverless.Handler, opts?: pulumi.ResourceOptions): Function {
-    return new Function(name, handler, /*isFactoryFunction*/ false, opts);
-}
-
-export function createFactoryFunction(
-        name: string, handler: aws.serverless.HandlerFactory, opts?: pulumi.ResourceOptions): Function {
-    return new Function(name, handler, /*isFactoryFunction*/ true, opts);
-}
-
 export function createCallbackFunction(
         name: string,
         handler: aws.serverless.Handler | aws.serverless.HandlerFactory,
@@ -63,8 +53,24 @@ export function createCallbackFunction(
     return new aws.lambda.CallbackFunction(name, args, opts);
 }
 
-// Function is a wrapper over aws.serverless.Function which configures policies and VPC settings based on
-// `@pulumi/cloud` configuration.
+/** @deprecated Use [createCallbackFunction] instead. */
+export function createFunction(
+        name: string, handler: aws.serverless.Handler, opts?: pulumi.ResourceOptions): Function {
+    return new Function(name, handler, /*isFactoryFunction*/ false, opts);
+}
+
+/** @deprecated Use [createCallbackFunction] instead. */
+export function createFactoryFunction(
+        name: string, handler: aws.serverless.HandlerFactory, opts?: pulumi.ResourceOptions): Function {
+    return new Function(name, handler, /*isFactoryFunction*/ true, opts);
+}
+
+/**
+ * [Function] is a wrapper over aws.serverless.Function which configures policies and VPC settings based on
+ * `@pulumi/cloud` configuration.
+ *
+ * @deprecated Use [createCallbackFunction] instead.
+ */
 export class Function extends pulumi.ComponentResource {
     public readonly handler: aws.serverless.Handler;
     public readonly lambda: aws.lambda.Function;

--- a/aws/httpServer.ts
+++ b/aws/httpServer.ts
@@ -20,7 +20,7 @@ import * as lambda from "@pulumi/aws/lambda";
 import * as cloud from "@pulumi/cloud";
 import * as pulumi from "@pulumi/pulumi";
 
-import { createFactoryFunction } from "./function";
+import { createCallbackFunction } from "./function";
 
 import * as serverlessExpress from "aws-serverless-express";
 
@@ -52,7 +52,8 @@ export class HttpServer extends pulumi.ComponentResource implements cloud.HttpSe
         };
 
         // Now, create the actual AWS lambda from that factory function.
-        const func = createFactoryFunction(name, entryPointFactory, { parent: this });
+        const callbackFunction = createCallbackFunction(
+            name, entryPointFactory, /*isFactoryFunction:*/ true, { parent: this });
 
         const api = new aws.apigateway.x.API(name, {
             // Register two paths in the Swagger spec, for the root and for a catch all under the
@@ -61,12 +62,12 @@ export class HttpServer extends pulumi.ComponentResource implements cloud.HttpSe
                 {
                     path: "/",
                     method: "ANY",
-                    eventHandler: func.lambda,
+                    eventHandler: callbackFunction,
                 },
                 {
                     path: "/{proxy+}",
                     method: "ANY",
-                    eventHandler: func.lambda,
+                    eventHandler: callbackFunction,
                 },
             ],
         }, { parent: this });

--- a/aws/yarn.lock
+++ b/aws/yarn.lock
@@ -53,8 +53,8 @@
     "@pulumi/pulumi" dev
 
 "@pulumi/aws@dev":
-  version "0.16.2-dev-1540850639-g0e25935"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.2-dev-1540850639-g0e25935.tgz#b2d8c3bee83bc2df7ee74e45ce5b92dd61b94f06"
+  version "0.16.2-dev-1541189467-gf6f40ce"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.2-dev-1541189467-gf6f40ce.tgz#80ac6440d27571b440509472f0a5c067a8858290"
   dependencies:
     "@pulumi/pulumi" dev
     builtin-modules "3.0.0"
@@ -63,15 +63,15 @@
     resolve "^1.7.1"
 
 "@pulumi/docker@dev":
-  version "0.16.1-dev-1540920513-gbaa8c1f"
-  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1540920513-gbaa8c1f.tgz#83a796d76f3d5efd9c1aec118de8d2b96ee9e925"
+  version "0.16.1-dev-1540920920-ge3768d1"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1540920920-ge3768d1.tgz#9d6ed977f0fc9803976cd8ebf92dedfa7940fcc4"
   dependencies:
     "@pulumi/pulumi" dev
     semver "^5.4.0"
 
 "@pulumi/pulumi@dev":
-  version "0.16.3-dev-1540908796-g0ac0cae7"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1540908796-g0ac0cae7.tgz#6815af7ad7c865455561fd9eff2800227c2754ee"
+  version "0.16.3-dev-1541212326-gafd53915"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1541212326-gafd53915.tgz#6a15669039b1d4be7d2e709eac6f007532ee8921"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -86,8 +86,8 @@
     upath "^1.1.0"
 
 "@types/aws-lambda@*":
-  version "8.10.14"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.14.tgz#979eaa4abafff8de93854fe5cc1ae6e0bb888913"
+  version "8.10.15"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.15.tgz#ea7094e9cacbcfa5e1b6b15baa12b7a438857fc7"
 
 "@types/aws-sdk@^2.7.0":
   version "2.7.0"
@@ -145,12 +145,12 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
 
 "@types/node@*", "@types/node@^10.1.0":
-  version "10.12.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
+  version "10.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
 
 "@types/node@^8.0.26":
-  version "8.10.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.36.tgz#eac05d576fbcd0b4ea3c912dc58c20475c08d9e4"
+  version "8.10.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.37.tgz#d2db49dc6a4e087c3245f22b92061f22494771e5"
 
 "@types/range-parser@*":
   version "1.2.2"
@@ -222,8 +222,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.344.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.344.0.tgz#950516888e9e8a85c006f3eb6b7fda28646f5c01"
+  version "2.348.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.348.0.tgz#69c5b6dd77a5eac85b54bf7cc1640c19d762d3ee"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -455,12 +455,12 @@ google-protobuf@^3.5.0:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
 grpc@^1.12.2:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.15.1.tgz#046263d9b0c440c8e36fece03e227cb3afe28514"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"
   dependencies:
     lodash "^4.17.5"
     nan "^2.0.0"
@@ -928,8 +928,8 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1042,8 +1042,8 @@ type-is@^1.6.16:
     mime-types "~2.1.18"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
 
 upath@^1.1.0:
   version "1.1.0"

--- a/azure/yarn.lock
+++ b/azure/yarn.lock
@@ -62,15 +62,15 @@
     "@pulumi/pulumi" dev
 
 "@pulumi/docker@dev":
-  version "0.16.1-dev-1540920513-gbaa8c1f"
-  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1540920513-gbaa8c1f.tgz#83a796d76f3d5efd9c1aec118de8d2b96ee9e925"
+  version "0.16.1-dev-1540920920-ge3768d1"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-0.16.1-dev-1540920920-ge3768d1.tgz#9d6ed977f0fc9803976cd8ebf92dedfa7940fcc4"
   dependencies:
     "@pulumi/pulumi" dev
     semver "^5.4.0"
 
 "@pulumi/pulumi@dev":
-  version "0.16.3-dev-1540908796-g0ac0cae7"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1540908796-g0ac0cae7.tgz#6815af7ad7c865455561fd9eff2800227c2754ee"
+  version "0.16.3-dev-1541212326-gafd53915"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.3-dev-1541212326-gafd53915.tgz#6a15669039b1d4be7d2e709eac6f007532ee8921"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -85,8 +85,8 @@
     upath "^1.1.0"
 
 "@types/aws-lambda@*":
-  version "8.10.14"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.14.tgz#979eaa4abafff8de93854fe5cc1ae6e0bb888913"
+  version "8.10.15"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.15.tgz#ea7094e9cacbcfa5e1b6b15baa12b7a438857fc7"
 
 "@types/aws-serverless-express@^3.0.1":
   version "3.3.0"
@@ -144,12 +144,12 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
 
 "@types/node@*", "@types/node@^10.1.0":
-  version "10.12.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
+  version "10.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
 
 "@types/node@^8.0.26", "@types/node@^8.0.47":
-  version "8.10.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.36.tgz#eac05d576fbcd0b4ea3c912dc58c20475c08d9e4"
+  version "8.10.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.37.tgz#d2db49dc6a4e087c3245f22b92061f22494771e5"
 
 "@types/range-parser@*":
   version "1.2.2"
@@ -764,12 +764,12 @@ google-protobuf@^3.5.0:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 graceful-fs@^4.1.2:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
 grpc@^1.12.2:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.15.1.tgz#046263d9b0c440c8e36fece03e227cb3afe28514"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"
   dependencies:
     lodash "^4.17.5"
     nan "^2.0.0"
@@ -1512,8 +1512,8 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1685,8 +1685,8 @@ type-is@^1.6.16, type-is@~1.6.16:
     mime-types "~2.1.18"
 
 typescript@^3.0.0, typescript@^3.0.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
 
 underscore@1.4.x:
   version "1.4.4"


### PR DESCRIPTION
This should not be a behavioral change for users.  However, it will be visible in stacks as the removal of an  intermediary resource.  There is an open question if that is a net negative.  Today, we use cloud.function.Function as a way to aggregate the underlying aws-lambda, along with its roles/rolepolicyattachments.  i.e.:

