### PR TITLE
Use On Demand for AWS Table

### DIFF
--- a/aws/package.json
+++ b/aws/package.json
@@ -12,7 +12,7 @@
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "dependencies": {
         "@pulumi/pulumi": "^0.16.4",
-        "@pulumi/aws": "^0.16.2",
+        "@pulumi/aws": "^0.16.4",
         "@pulumi/aws-infra": "^0.16.1",
         "@pulumi/docker": "^0.16.1",
         "aws-serverless-express": "^3.3.5",

--- a/aws/table.ts
+++ b/aws/table.ts
@@ -61,8 +61,7 @@ export class Table extends pulumi.ComponentResource implements cloud.Table {
                 type: pulumi.output(primaryKeyType).apply(t => pulumiKeyTypeToDynamoKeyType(t)),
             }],
             hashKey: primaryKey,
-            readCapacity: 5,
-            writeCapacity: 5,
+            billingMode: "PAY_PER_REQUEST",
         }, { parent: this });
 
         const tableName = this.dynamodbTable.name;


### PR DESCRIPTION
The AWS Table implementation used DynamoDB with an opaque and not-configurable fixed provisioning.  This has been problematic for several reasons:
1. It does not scale with load
2. It incurs a fixed cost even when not used
3. It would require AWS-specific provisioning hooks to expose control

With the recent release of On Demand billing mode for DynamoDB, we can now avoid all three problems by setting Table to On Demand provisioning which will scale with demand (including to zero).

We may in the future allow AWS-specific options to override this, but this makes much more sense as the default for this library.

Note that the change from Provisioned to On Demand does not require replacement of the Table, it can be updated in place.  The update itself does take ~5minutes to complete, but it otherwise non-disruptive to use of the Table.

Fixes #31.