### PR TITLE
Fix crawler example so it compiles again

### DIFF
--- a/examples/crawler/index.ts
+++ b/examples/crawler/index.ts
@@ -89,7 +89,7 @@ sites.subscribe("foreachurl", async (url) => {
     });
 
     // Loop over all `<a href=...>` that match our filter, and collect in a local Set.
-    let links = new Set();
+    let links = new Set<string>();
     let anchors = $("a", html);
     for (let i = 0; i < anchors.length; i++) {
         let rawHref = anchors[i].attribs["href"];


### PR DESCRIPTION
Recent changes have caused this example to stop building with an error
like:

```
index.ts:111:33 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.

111             await sites.publish(link);
```

Simply set a type for our set of links.