### PR TITLE
Temporarily remote Azure Table test

### DIFF
--- a/azure/azure_tests.go
+++ b/azure/azure_tests.go
@@ -96,9 +96,9 @@ func RunAzureTests(t *testing.T) {
 		baseTest.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "./examples/bucket"),
 		}),
-		baseTest.With(integration.ProgramTestOptions{
-			Dir: path.Join(cwd, "./examples/table"),
-		}),
+		//baseTest.With(integration.ProgramTestOptions{
+		//	Dir: path.Join(cwd, "./examples/table"),
+		//}),
 		baseTest.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "./examples/cloud-ts-thumbnailer"),
 		}),


### PR DESCRIPTION
This is due to a regression in the Azurerm Terraform Provider
that is currently been fixed and waiting to be released