### PR TITLE
Update AWS and Pulumi dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD (Unreleased)
+
+- Update `@pulumi/aws` and `@pulumi/pulumi` dependencies to 1.0.0
+
 ## 0.18.1 (Release July 15, 2019)
 
 ### Important

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,7 @@
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "types": "types.d.ts",
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.4"
+        "@pulumi/pulumi": "^1.0.0"
     },
     "devDependencies": {
         "@types/node": "^10.0.0",

--- a/aws/package.json
+++ b/aws/package.json
@@ -11,8 +11,8 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.4",
-        "@pulumi/aws": "^0.18.0",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0",
         "@pulumi/awsx": "^0.18.0",
         "@pulumi/docker": "^0.17.0",
         "aws-serverless-express": "^3.3.5",


### PR DESCRIPTION
The `cloud-azure` package is not updated because it still depenends on
`azure-serverless`, which is now deprecated (and so it depends on a
pre 1.0.0 version of azure as well).

As part of addressing #750 we should update to use 1.0.0 of
`@pulumi/pulumi` and `@pulumi/azure` in `@pulumi/cloud-azure`.