### PR TITLE
Move to latest awsx version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
  - Upgrade to go1.13.x
+ - Upgrade to latest version of `@pulumi/awsx`.
 
 ## 0.18.2 (Release November 6, 2019)
 

--- a/aws/aws.ts
+++ b/aws/aws.ts
@@ -1,0 +1,42 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO[pulumi/pulumi-aws#40]: Move these to pulumi-aws.
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+// Compute the availability zones only once, and store the resulting promise.
+let zones: Promise<string[]> | undefined;
+
+/** @internal */
+export async function getAvailabilityZone(index: number, opts?: pulumi.InvokeOptions): Promise<string> {
+    const azs = await getAvailabilityZones(opts);
+    return azs[index];
+}
+
+/** @internal */
+export function getAvailabilityZones(opts?: pulumi.InvokeOptions): Promise<string[]> {
+    if (opts === undefined) {
+        // Only cache the results if 'opts' is not passed in.  If there are opts, it may change the
+        // results and we can't necessarily reuse any previous results.
+        if (!zones) {
+            zones = aws.getAvailabilityZones(/*args:*/ undefined, { async: true }).then(r => r.names);
+        }
+
+        return zones;
+    }
+
+    return aws.getAvailabilityZones(/*args:*/ undefined, { ...opts, async: true }).then(r => r.names);
+}

--- a/aws/cluster.ts
+++ b/aws/cluster.ts
@@ -1,0 +1,484 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+import { Network } from "./network";
+
+import { sha1hash } from "./utils";
+
+// The default path to use for mounting EFS inside ECS container instances.
+const defaultEfsMountPath = "/mnt/efs";
+
+/**
+ * @deprecated Usages of awsx.Cluster should be migrated to awsx.ecs.Cluster.
+ * @internal
+ */
+export interface ClusterNetworkArgs {
+    /**
+     * The VPC id of the network for the cluster
+     */
+    vpcId: pulumi.Input<string>;
+    /**
+     * The network subnets for the clusters
+     */
+    subnetIds: pulumi.Input<string>[];
+}
+
+/**
+ * Arguments bag for creating infrastructure for a new Cluster.
+ * @deprecated Usages of awsx.Cluster should be migrated to awsx.ecs.Cluster.
+ * @internal
+ */
+export interface ClusterArgs {
+    /**
+     * The network in which to create this cluster.
+     */
+    network: ClusterNetworkArgs;
+    /**
+     * Whether to create an EFS File System to manage volumes across the cluster.
+     */
+    addEFS: boolean;
+    /**
+     * The EC2 instance type to use for the Cluster.  Defaults to `t2.micro`.
+     */
+    instanceType?: string;
+    /**
+     * The policy to apply to the cluster instance role.
+     *
+     * The default is `["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+     * "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"]`.
+     */
+    instanceRolePolicyARNs?: string[];
+    /**
+     * The size (in GiB) of the EBS volume to attach to each instance as the root volume.
+     *
+     * The default is 8 GiB.
+     */
+    instanceRootVolumeSize?: number;
+    /**
+     * The size (in GiB) of the EBS volume to attach to each instance to use for Docker image and metadata storage.
+     *
+     * The default is 50 GiB.
+     */
+    instanceDockerImageVolumeSize?: number;
+    /**
+     * The size (in GiB) of the EBS volume to attach to each instance for swap space.
+     *
+     * The default is 5 GiB.
+     */
+    instanceSwapVolumeSize?: number;
+    /**
+     * The minimum size of the cluster. Defaults to 2.
+     */
+    minSize?: number;
+    /**
+     * The maximum size of the cluster. Setting to 0 will prevent an EC2 AutoScalingGroup from being created. Defaults
+     * to 100.
+     */
+    maxSize?: number;
+    /**
+     * Public key material for SSH access. See allowed formats at:
+     * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
+     * If not provided, no SSH access is enabled on VMs.
+     */
+    publicKey?: string;
+    /**
+     * The name of the ECS-optimzed AMI to use for the Container Instances in this cluster, e.g.
+     * "amzn-ami-2017.09.l-amazon-ecs-optimized". Defaults to using the latest recommended ECS Optimized AMI, which may
+     * change over time and cause recreation of EC2 instances when new versions are release. To control when these
+     * changes are adopted, set this parameter explicitly to the version you would like to use.
+     *
+     * See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html for valid values.
+     */
+    ecsOptimizedAMIName?: string;
+}
+
+/**
+ * A Cluster is a general purpose ECS cluster configured to run in a provided
+ * Network.
+ *
+ * @deprecated Usages of awsx.Cluster should be migrated to awsx.ecs.Cluster.
+ * @internal
+ */
+export class Cluster extends pulumi.ComponentResource {
+    /**
+     * The network in which to create this cluster.
+     */
+    public readonly network: ClusterNetworkArgs;
+    /**
+     * The ECS Cluster ARN.
+     */
+    public readonly ecsClusterARN: pulumi.Output<string>;
+    /**
+     * The ECS Cluster's Security Group ID.
+     */
+    public readonly securityGroupId?: pulumi.Output<string>;
+    /**
+     * The auto-scaling group that ECS Service's should add to their
+     * `dependsOn`.
+     */
+    public readonly autoScalingGroupStack?: pulumi.Resource;
+    /**
+     * The EFS host mount path if EFS is enabled on this Cluster.
+     */
+    public readonly efsMountPath?: string;
+
+    constructor(name: string, args: ClusterArgs, opts?: pulumi.ComponentResourceOptions) {
+        if (!args.network) {
+            throw new pulumi.RunError("Expected a valid Network to use for creating Cluster");
+        }
+
+        super("awsx:cluster:Cluster", name, {}, opts);
+
+        this.network = args.network;
+
+        // First create an ECS cluster.
+        const cluster = new aws.ecs.Cluster(name, {}, { parent: this });
+        this.ecsClusterARN = cluster.id;
+
+        // Create the EC2 instance security group
+        const ALL = {
+            fromPort: 0,
+            toPort: 0,
+            protocol: "-1",  // all
+            cidrBlocks: [ "0.0.0.0/0" ],
+        };
+        // IDEA: Can we re-use the network's default security group instead of creating a specific
+        // new security group in the Cluster layer?  This may allow us to share a single Security Group
+        // across both instance and Lambda compute.
+        const instanceSecurityGroup = new aws.ec2.SecurityGroup(name, {
+            vpcId: args.network.vpcId,
+            ingress: [
+                // Expose SSH
+                {
+                    fromPort: 22,
+                    toPort: 22,
+                    protocol: "TCP",
+                    cidrBlocks: [ "0.0.0.0/0" ],
+                },
+                // Expose ephemeral container ports to Internet.
+                // TODO: Limit to load balancer(s).
+                {
+                    fromPort: 0,
+                    toPort: 65535,
+                    protocol: "TCP",
+                    cidrBlocks: [ "0.0.0.0/0" ],
+                },
+            ],
+            egress: [ ALL ],  // See TerraformEgressNote
+            tags: {
+                Name: name,
+            },
+        }, { parent: this });
+        this.securityGroupId = instanceSecurityGroup.id;
+
+        // If requested, add EFS file system and mount targets in each subnet.
+        let filesystem: aws.efs.FileSystem | undefined;
+        if (args.addEFS) {
+            filesystem = new aws.efs.FileSystem(name, {}, { parent: this });
+            const efsSecurityGroupName = `${name}-fs`;
+            const efsSecurityGroup = new aws.ec2.SecurityGroup(efsSecurityGroupName, {
+                vpcId: args.network.vpcId,
+                ingress: [
+                    // Allow NFS traffic from the instance security group
+                    {
+                        securityGroups: [ instanceSecurityGroup.id ],
+                        protocol: "TCP",
+                        fromPort: 2049,
+                        toPort: 2049,
+                    },
+                ],
+                tags: {
+                    Name: efsSecurityGroupName,
+                },
+            }, { parent: this });
+            for (let i = 0; i <  args.network.subnetIds.length; i++) {
+                const subnetId = args.network.subnetIds[i];
+                const mountTarget = new aws.efs.MountTarget(`${name}-${i}`, {
+                    fileSystemId: filesystem.id,
+                    subnetId: subnetId,
+                    securityGroups: [ efsSecurityGroup.id ],
+                }, { parent: this });
+            }
+            this.efsMountPath = defaultEfsMountPath;
+        }
+
+        // If we were asked to not create any EC2 instances, then we are done, else create an AutoScalingGroup.
+        if (args.maxSize !== 0) {
+            this.autoScalingGroupStack = createAutoScalingGroup(
+                this, name, args, instanceSecurityGroup, cluster, filesystem);
+        }
+
+        this.registerOutputs();
+    }
+}
+
+// Create an AutoScalingGroup for the EC2 container instances specified by the cluster arguments, registered with the
+// provided cluster and mounting the provided filesystem
+function createAutoScalingGroup(
+        parent: Cluster,
+        name: string,
+        args: ClusterArgs,
+        securityGroup: aws.ec2.SecurityGroup,
+        cluster: aws.ecs.Cluster,
+        filesystem: aws.efs.FileSystem | undefined): aws.cloudformation.Stack {
+
+    const efsMountPath = parent.efsMountPath;
+
+    // Next create all of the IAM/security resources.
+    const assumeInstanceRolePolicyDoc: aws.iam.PolicyDocument = {
+        Version: "2012-10-17",
+        Statement: [{
+            Action: [
+                "sts:AssumeRole",
+            ],
+            Effect: "Allow",
+            Principal: {
+                Service: [ "ec2.amazonaws.com" ],
+            },
+        }],
+    };
+    const instanceRole = new aws.iam.Role(name, {
+        assumeRolePolicy: JSON.stringify(assumeInstanceRolePolicyDoc),
+    }, { parent: parent });
+    const policyARNs = args.instanceRolePolicyARNs
+        || [aws.iam.AmazonEC2ContainerServiceforEC2Role, aws.iam.AmazonEC2ReadOnlyAccess];
+    const instanceRolePolicies: aws.iam.RolePolicyAttachment[] = [];
+    for (let i = 0; i < policyARNs.length; i++) {
+        const policyARN = policyARNs[i];
+        const instanceRolePolicy = new aws.iam.RolePolicyAttachment(`${name}-${sha1hash(policyARN)}`, {
+            role: instanceRole,
+            policyArn: policyARN,
+        }, { parent: parent });
+        instanceRolePolicies.push(instanceRolePolicy);
+    }
+    const instanceProfile = new aws.iam.InstanceProfile(name, {
+        role: instanceRole,
+    }, { dependsOn: instanceRolePolicies, parent: parent });
+
+    // If requested, add a new EC2 KeyPair for SSH access to the instances.
+    let keyName: pulumi.Output<string> | undefined;
+    if (args.publicKey) {
+        const key = new aws.ec2.KeyPair(name, {
+            publicKey: args.publicKey,
+        }, { parent: parent });
+        keyName = key.keyName;
+    }
+
+    // Create the full name of our CloudFormation stack here explicitly. Since the CFN stack references the
+    // launch configuration and vice-versa, we use this to break the cycle.
+    // TODO[pulumi/pulumi#381]: Creating an S3 bucket is an inelegant way to get a durable, unique name.
+    const cloudFormationStackName = new aws.s3.Bucket(name).id;
+
+    // Specify the intance configuration for the cluster.
+    const instanceLaunchConfiguration = new aws.ec2.LaunchConfiguration(name, {
+        imageId: getEcsAmiId(args.ecsOptimizedAMIName),
+        instanceType: args.instanceType || "t2.micro",
+        keyName: keyName,
+        iamInstanceProfile: instanceProfile.id,
+        enableMonitoring: true,  // default is true
+        placementTenancy: "default",  // default is "default"
+        rootBlockDevice: {
+            volumeSize: args.instanceRootVolumeSize || 8, // GiB
+            volumeType: "gp2", // default is "standard"
+            deleteOnTermination: true,
+        },
+        ebsBlockDevices: [
+            {
+                // Swap volume
+                deviceName: "/dev/xvdb",
+                volumeSize: args.instanceSwapVolumeSize || 5, // GiB
+                volumeType: "gp2", // default is "standard"
+                deleteOnTermination: true,
+            },
+            {
+                // Docker image and metadata volume
+                deviceName: "/dev/xvdcz",
+                volumeSize: args.instanceDockerImageVolumeSize || 50, // GiB
+                volumeType: "gp2",
+                deleteOnTermination: true,
+            },
+        ],
+        securityGroups: [ securityGroup.id ],
+        userData: getInstanceUserData(cluster, filesystem, efsMountPath, cloudFormationStackName),
+    }, { parent: parent });
+
+    // Finally, create the AutoScaling Group.
+    return new aws.cloudformation.Stack(name, {
+            name: cloudFormationStackName,
+            templateBody: getCloudFormationAsgTemplate(
+                name,
+                args.minSize || 2,
+                args.maxSize || 100,
+                instanceLaunchConfiguration.id,
+                args.network.subnetIds,
+            ),
+        }, { parent: parent });
+}
+
+(<any>Cluster).doNotCapture = true;
+
+// http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container_agent_versions.html
+async function getEcsAmiId(name?: string) {
+    // If a name was not provided, use the latest recommended version.
+    if (!name) {
+        // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
+        const ecsRecommendedAMI = await aws.ssm.getParameter({
+            name: "/aws/service/ecs/optimized-ami/amazon-linux/recommended",
+        });
+        return JSON.parse(ecsRecommendedAMI.value).image_id;
+    }
+    // Else, if a name was provided, look it up and use that imageId.
+    const result: aws.GetAmiResult = await aws.getAmi({
+        owners: [
+            "591542846629", // Amazon
+        ],
+        filters: [
+            {
+                name: "name",
+                values: [ name ],
+            },
+        ],
+        mostRecent: true,
+    });
+    return result.imageId;
+}
+
+// http://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data
+// ours seems inspired by:
+// https://github.com/convox/rack/blob/023831d8/provider/aws/dist/rack.json#L1669
+// https://github.com/awslabs/amazon-ecs-amazon-efs/blob/d92791f3/amazon-efs-ecs.json#L655
+function getInstanceUserData(
+    cluster: aws.ecs.Cluster,
+    fileSystem: aws.efs.FileSystem | undefined,
+    mountPath: string | undefined,
+    cloudFormationStackName: pulumi.Output<string>) {
+
+    const fileSystemId = fileSystem ? fileSystem.id : undefined;
+
+    const all = pulumi.all([fileSystemId, cluster.id, cloudFormationStackName]);
+    return all.apply(([fsId, clusterId, stackName]) => {
+        let fileSystemRuncmdBlock = "";
+        if (fileSystem && mountPath) {
+            // This string must be indented exactly as much as the block of commands it's inserted into below!
+
+            // tslint:disable max-line-length
+            fileSystemRuncmdBlock = `
+                # Create EFS mount path
+                mkdir ${mountPath}
+                chown ec2-user:ec2-user ${mountPath}
+                # Create environment variables
+                EFS_FILE_SYSTEM_ID=${fsId}
+                DIR_SRC=$AWS_AVAILABILITY_ZONE.$EFS_FILE_SYSTEM_ID.efs.$AWS_REGION.amazonaws.com
+                DIR_TGT=${mountPath}
+                # Update /etc/fstab with the new NFS mount
+                cp -p /etc/fstab /etc/fstab.back-$(date +%F)
+                echo -e \"$DIR_SRC:/ $DIR_TGT nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0\" | tee -a /etc/fstab
+                mount -a -t nfs4
+                # Restart Docker
+                docker ps
+                service docker stop
+                service docker start
+            `;
+        }
+
+        return `#cloud-config
+        repo_upgrade_exclude:
+            - kernel*
+        packages:
+            - aws-cfn-bootstrap
+            - aws-cli
+            - nfs-utils
+        mounts:
+            - ['/dev/xvdb', 'none', 'swap', 'sw', '0', '0']
+        bootcmd:
+            - mkswap /dev/xvdb
+            - swapon /dev/xvdb
+            - echo ECS_CLUSTER='${clusterId}' >> /etc/ecs/ecs.config
+            - echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
+        runcmd:
+            # Set and use variables in the same command, since it's not obvious if
+            # different commands will run in different shells.
+            - |
+                # Knock one letter off of availability zone to get region.
+                AWS_AVAILABILITY_ZONE=$(curl -s 169.254.169.254/2016-09-02/meta-data/placement/availability-zone)
+                AWS_REGION=$(echo $AWS_AVAILABILITY_ZONE | sed 's/.$//')
+
+                ${fileSystemRuncmdBlock}
+
+                # Disable container access to EC2 metadata instance
+                # See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html
+                iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP
+                service iptables save
+
+                /opt/aws/bin/cfn-signal \
+                    --region "\${AWS_REGION}" \
+                    --stack "${stackName}" \
+                    --resource Instances
+        `;
+    });
+}
+
+// TODO[pulumi/pulumi-aws/issues#43]: We'd prefer not to use CloudFormation, but it's the best way to implement
+// rolling updates in an autoscaling group.
+function getCloudFormationAsgTemplate(
+    instanceName: string,
+    minSize: number,
+    maxSize: number,
+    instanceLaunchConfigurationId: pulumi.Output<string>,
+    subnetIds: pulumi.Input<string>[]): pulumi.Output<string> {
+
+    const subnetsIdsArray = pulumi.all(subnetIds);
+    return pulumi.all([subnetsIdsArray, instanceLaunchConfigurationId])
+                 .apply(([array, configId]) => {
+    return `
+    AWSTemplateFormatVersion: '2010-09-09'
+    Outputs:
+        Instances:
+            Value: !Ref Instances
+    Resources:
+        Instances:
+            Type: AWS::AutoScaling::AutoScalingGroup
+            Properties:
+                Cooldown: 300
+                DesiredCapacity: ${minSize}
+                HealthCheckGracePeriod: 120
+                HealthCheckType: EC2
+                LaunchConfigurationName: "${configId}"
+                MaxSize: ${maxSize}
+                MetricsCollection:
+                -   Granularity: 1Minute
+                MinSize: ${minSize}
+                VPCZoneIdentifier: ${JSON.stringify(array)}
+                Tags:
+                -   Key: Name
+                    Value: ${instanceName}
+                    PropagateAtLaunch: true
+            CreationPolicy:
+                ResourceSignal:
+                    Count: ${minSize}
+                    Timeout: PT15M
+            UpdatePolicy:
+                AutoScalingRollingUpdate:
+                    MaxBatchSize: 1
+                    MinInstancesInService: ${minSize}
+                    PauseTime: PT15M
+                    SuspendProcesses:
+                    -   ScheduledActions
+                    WaitOnResourceSignals: true
+    `;
+                 });
+}

--- a/aws/network.ts
+++ b/aws/network.ts
@@ -1,0 +1,316 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import { RunError } from "@pulumi/pulumi/errors";
+import { getAvailabilityZone } from "./aws";
+
+import { ifUndefined } from "./utils";
+
+/**
+ * Optional arguments that can be provided when creating a network.
+ *
+ * @deprecated Usages of awsx.Network should be migrated to awsx.ec2.Vpc.
+ * @internal
+ */
+export interface NetworkArgs {
+    /**
+     * The maximum number of availability zones to use in the current region.  Defaults to '2' if
+     * unspecified.
+     */
+    readonly numberOfAvailabilityZones?: number;
+    readonly usePrivateSubnets?: boolean;
+
+    /**
+     * The CIDR block for the VPC.  Defaults to "10.10.0.0/16" if unspecified.
+     */
+    cidrBlock?: pulumi.Input<string>;
+
+    /**
+     * Whether or not to have DNS hostnames in the VPC. Defaults to 'true' if unspecified.
+     */
+    enableDnsHostnames?: pulumi.Input<boolean>;
+
+    /**
+     * Whether or not to have DNS support in the VPC.  Defaults to 'true' if unspecified.
+     */
+    enableDnsSupport?: pulumi.Input<boolean>;
+
+    /**
+     * A tenancy option for instances launched into the VPC.  Defaults to 'default' if unspecified.
+     */
+    instanceTenancy?: pulumi.Input<"default" | "dedicated">;
+}
+
+/**
+ * Arguments necessary when creating a network using Network.fromVpc.
+ *
+ * @deprecated Usages of awsx.Network should be migrated to awsx.ec2.Vpc.
+ * @internal
+ */
+export interface NetworkVpcArgs {
+    /**
+     * The VPC id of the network for the cluster
+     */
+    readonly vpcId: pulumi.Input<string>;
+    /**
+     * The network subnets for the clusters
+     */
+    readonly subnetIds: pulumi.Input<string>[];
+    /**
+     * Whether the network includes private subnets.
+     */
+    readonly usePrivateSubnets: boolean;
+    /**
+     * The security group IDs for the network.
+     */
+    readonly securityGroupIds: pulumi.Input<string>[];
+    /**
+     * The public subnets for the VPC.  In case [usePrivateSubnets] == false, these are the same as [subnets].
+     */
+    readonly publicSubnetIds: pulumi.Input<string>[];
+}
+
+// The lazily initialized default network instance.
+let defaultNetwork: Network;
+
+/**
+ * Network encapsulates the configuration of an Amazon VPC.  Both [VPC with Public
+ * Subnet](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario1.html) and [VPC with Public and Private
+ * Subnets (NAT)](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html) configurations are
+ * supported.
+ *
+ * @deprecated Usages of awsx.Network should be migrated to awsx.ec2.Vpc.
+ * @internal
+ */
+export class Network extends pulumi.ComponentResource {
+    /**
+     * The VPC id of the network.
+     */
+    public readonly vpcId: pulumi.Output<string>;
+    /**
+     * Whether the network includes private subnets.
+     */
+    public readonly usePrivateSubnets: boolean;
+    /**
+     * The security group IDs for the network.
+     */
+    public readonly securityGroupIds: pulumi.Output<string>[];
+    /**
+     * The subnets in which compute should run.  These are the private subnets if
+     * [usePrivateSubnets] == true, else these are the public subnets.
+     */
+    public readonly subnetIds: pulumi.Output<string>[];
+    /**
+     * The public subnets for the VPC.  In case [usePrivateSubnets] == false, these are the same as
+     * [subnets].
+     */
+    public readonly publicSubnetIds: pulumi.Output<string>[];
+
+    /**
+     * The public subnet route table for the VPC.
+     */
+    public readonly publicRouteTableId: pulumi.Output<string> | undefined;
+    /**
+     * Gets the default VPC for the AWS account as a Network.  This first time this is called, the
+     * default network will be lazily created, using whatever options are provided in opts. All
+     * subsequent calls will return that same network even if different opts are provided.
+     */
+    public static getDefault(opts?: pulumi.ComponentResourceOptions): Network {
+        if (!defaultNetwork) {
+            const vpc = aws.ec2.getVpc({default: true});
+            const vpcId = vpc.id;
+            const subnetIds = aws.ec2.getSubnetIds({ vpcId }).ids;
+            const defaultSecurityGroup = aws.ec2.getSecurityGroup(
+                { name: "default", vpcId },
+            ).id;
+            const subnet0 = subnetIds[0];
+            const subnet1 = subnetIds[1];
+
+            defaultNetwork = this.fromVpc("default-vpc", {
+                vpcId: vpcId,
+                subnetIds: [ subnet0, subnet1 ],
+                usePrivateSubnets: false,
+                securityGroupIds: [ defaultSecurityGroup ],
+                publicSubnetIds: [ subnet0, subnet1 ],
+            }, opts);
+        }
+
+        return defaultNetwork;
+    }
+
+    /**
+     * Creates a new network using the configuration values of an existing VPC.
+     */
+    public static fromVpc(name: string, vpcArgs: NetworkVpcArgs, opts?: pulumi.ComponentResourceOptions): Network {
+        if (!vpcArgs.vpcId) {
+            throw new RunError("vpcArgs.vpcId must be provided.");
+        }
+        if (!vpcArgs.subnetIds) {
+            throw new RunError("vpcArgs.subnetIds must be provided.");
+        }
+        if (!vpcArgs.securityGroupIds) {
+            throw new RunError("vpcArgs.securityGroupIds must be provided.");
+        }
+        if (!vpcArgs.publicSubnetIds) {
+            throw new RunError("vpcArgs.publicSubnetIds must be provided.");
+        }
+
+        return new Network(name, vpcArgs, opts);
+    }
+
+    constructor(name: string, args?: NetworkArgs, opts?: pulumi.ComponentResourceOptions);
+    constructor(name: string, mergedArgs: NetworkArgs | NetworkVpcArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
+        super("awsx:network:Network", name, {}, opts);
+
+        // IDEA: default to the number of availability zones in this region, rather than 2.  To do this requires
+        // invoking the provider, which requires that we "go async" at a very inopportune time here.  When
+        // pulumi/pulumi#331 lands, this will be much easier to do, and we can improve this situation.
+
+        const parentOpts = { parent: this };
+        const vpcArgs = <NetworkVpcArgs>mergedArgs;
+
+        if (vpcArgs.vpcId) {
+            this.vpcId = pulumi.output(vpcArgs.vpcId);
+            this.subnetIds = vpcArgs.subnetIds.map(id => pulumi.output(id));
+            this.usePrivateSubnets = vpcArgs.usePrivateSubnets;
+            this.securityGroupIds = vpcArgs.securityGroupIds.map(id => pulumi.output(id));
+            this.publicSubnetIds = vpcArgs.publicSubnetIds.map(id => pulumi.output(id));
+            return;
+        }
+
+        const args = <NetworkArgs>mergedArgs;
+        const numberOfAvailabilityZones = args.numberOfAvailabilityZones || 2;
+        if (numberOfAvailabilityZones < 1 || numberOfAvailabilityZones > 4) {
+            throw new RunError(
+                `Unsupported number of availability zones for network: ${numberOfAvailabilityZones}`);
+        }
+
+        const tags = { Name: name };
+
+        this.usePrivateSubnets = args.usePrivateSubnets || false;
+
+        const vpc = new aws.ec2.Vpc(name, {
+            cidrBlock: ifUndefined(args.cidrBlock, "10.10.0.0/16"),
+            enableDnsHostnames: ifUndefined(args.enableDnsHostnames, true),
+            enableDnsSupport: ifUndefined(args.enableDnsSupport, true),
+            tags,
+        }, parentOpts);
+
+        this.vpcId = vpc.id;
+
+        this.securityGroupIds = [ vpc.defaultSecurityGroupId ];
+        this.subnetIds = [];
+        this.publicSubnetIds = [];
+
+        const internetGateway = new aws.ec2.InternetGateway(name, {
+            vpcId: vpc.id,
+            tags,
+        }, parentOpts);
+
+        const publicRouteTable = new aws.ec2.RouteTable(name, {
+            vpcId: vpc.id,
+            routes: [{
+                    cidrBlock: "0.0.0.0/0",
+                    gatewayId: internetGateway.id,
+                }],
+            tags,
+        }, parentOpts);
+        this.publicRouteTableId = publicRouteTable.id;
+
+        for (let i = 0; i < numberOfAvailabilityZones; i++) {
+            const subnetName = `${name}-${i}`;
+            // Create the subnet for this AZ - either - either public or private
+            const subnet = new aws.ec2.Subnet(subnetName, {
+                vpcId: vpc.id,
+                availabilityZone: getAvailabilityZone(i),
+                cidrBlock: `10.10.${i}.0/24`,         // IDEA: Consider larger default CIDR block sizing
+                mapPublicIpOnLaunch: !this.usePrivateSubnets, // Only assign public IP if we are exposing public subnets
+                tags: { Name: subnetName },
+            }, parentOpts);
+
+            // We will use a different route table for this subnet depending on
+            // whether we are in a public or private subnet
+            const subnetRouteTable = createSubnetRouteTable(
+                this, publicRouteTable, subnet, name, i);
+
+            const routeTableAssociation = new aws.ec2.RouteTableAssociation(`${name}-${i}`, {
+                subnetId: subnet.id,
+                routeTableId: subnetRouteTable.id,
+            }, parentOpts);
+
+            // Record the subnet id, but depend on the RouteTableAssociation
+            const subnetId = pulumi.all([subnet.id, routeTableAssociation.id]).apply(([id]) => id);
+            this.subnetIds.push(subnetId);
+        }
+    }
+}
+
+function createSubnetRouteTable(
+        network: Network, publicRouteTable: aws.ec2.RouteTable,
+        subnet: aws.ec2.Subnet, name: string, index: number) {
+    const parentOpts = { parent: network };
+
+    if (!network.usePrivateSubnets) {
+        // The subnet is public, so register it as our public subnet
+        network.publicSubnetIds.push(subnet.id);
+        return publicRouteTable;
+    }
+
+    // We need a public subnet for the NAT Gateway
+    const natName = `${name}-nat-${index}`;
+    const tags = { Name: natName };
+
+    const natGatewayPublicSubnet = new aws.ec2.Subnet(natName, {
+        vpcId: network.vpcId,
+        availabilityZone: getAvailabilityZone(index),
+        cidrBlock: `10.10.${index+64}.0/24`, // Use top half of the subnet space
+        mapPublicIpOnLaunch: true,        // Always assign a public IP in NAT subnet
+        tags,
+    }, parentOpts);
+
+    // And we need to route traffic from that public subnet to the Internet Gateway
+    const natGatewayRoutes = new aws.ec2.RouteTableAssociation(natName, {
+        subnetId: natGatewayPublicSubnet.id,
+        routeTableId: publicRouteTable.id,
+    }, parentOpts);
+
+    // Record the subnet id, but depend on the RouteTableAssociation
+    const natGatewayPublicSubnetId =
+        pulumi.all([natGatewayPublicSubnet.id, natGatewayRoutes.id]).apply(([id]) => id);
+    network.publicSubnetIds.push(natGatewayPublicSubnetId);
+
+    // We need an Elastic IP for the NAT Gateway
+    const eip = new aws.ec2.Eip(natName, {}, parentOpts);
+
+    // And we need a NAT Gateway to be able to access the Internet
+    const natGateway = new aws.ec2.NatGateway(natName, {
+        subnetId: natGatewayPublicSubnet.id,
+        allocationId: eip.id,
+        tags,
+    }, parentOpts);
+
+    const natRouteTable = new aws.ec2.RouteTable(natName, {
+        vpcId: network.vpcId,
+        routes: [{
+            cidrBlock: "0.0.0.0/0",
+            natGatewayId: natGateway.id,
+        }],
+        tags,
+    }, parentOpts);
+
+    // Route through the NAT gateway for the private subnet
+    return natRouteTable;
+}

--- a/aws/package.json
+++ b/aws/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.0",
+        "@pulumi/awsx": "^0.19.0",
         "@pulumi/docker": "^0.17.0",
         "aws-serverless-express": "^3.3.5",
         "mime": "^2.0.3",
@@ -27,7 +27,7 @@
         "@types/aws-serverless-express": "^3.0.1",
         "@types/express": "^4.16.0",
         "tslint": "^5.11.0",
-        "typescript": "^3.0.3"
+        "typescript": "^3.7.4"
     },
     "peerDependencies": {
         "@pulumi/cloud": "${VERSION}"

--- a/aws/tsconfig.json
+++ b/aws/tsconfig.json
@@ -17,7 +17,10 @@
     "files": [
         "index.ts",
         "api.ts",
+        "aws.ts",
+        "cluster.ts",
         "function.ts",
+        "network.ts",
         "table.ts",
         "timer.ts",
         "topic.ts",

--- a/aws/utils.ts
+++ b/aws/utils.ts
@@ -38,3 +38,9 @@ export function apply<T, U>(val: Record<string, T>, func: (t: T) => U): Record<s
 export function liftResource<T extends pulumi.Resource>(resource: T): pulumi.Output<T> {
     return resource.urn.apply(_ => resource);
 }
+
+/** @internal */
+export function ifUndefined<T>(input: pulumi.Input<T> | undefined, value: pulumi.Input<T>): pulumi.Output<T> {
+    return <any>pulumi.all([input, value])
+                      .apply(([input, value]) => input !== undefined ? input : value);
+}

--- a/azure/httpServer.ts
+++ b/azure/httpServer.ts
@@ -195,7 +195,7 @@ function handleIncomingMessage(server: http.Server, azureContext: subscription.C
         }
 
         const awsEvent: AWSEvent = {
-            path: path,
+            path: path!,
             httpMethod: azureRequest.method,
             headers: azureRequest.headers || {},
             queryStringParameters: azureRequest.query || {},


### PR DESCRIPTION
In awsx we deprecated and finally removed awsx.Cluster and awsx.Network.  To be able to simply move Cloud over with minimal effort, I am simply moving those types into this package as an implementation detail.  