### PR TITLE
Fix function creation for topic subscriptions

### DIFF
--- a/aws/topic.ts
+++ b/aws/topic.ts
@@ -65,6 +65,6 @@ export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T>
         const lambda = createCallbackFunction(
             subscriptionName, eventHandler, /*isFactoryFunction:*/ false, opts);
 
-        this.topic.onEvent(subscriptionName, eventHandler, {}, opts);
+        this.topic.onEvent(subscriptionName, lambda, {}, opts);
     }
 }


### PR DESCRIPTION
Topic subscription wasn't using the created callback function, which led to two functions being created and the one without the appropriate options being associated