### PR TITLE
Do not mark ClusterNetworkArgs as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 
+- Expose the type `cluster.ClusterNetworkArgs` in `@pulumi/cloud-aws`
+
 ## 0.21.0 (Release May 22, 2020)
 
 - Update dependencies to allow for both 1.x and 2.x versions of `@pulumi/docker`

--- a/aws/cluster.ts
+++ b/aws/cluster.ts
@@ -24,7 +24,6 @@ const defaultEfsMountPath = "/mnt/efs";
 
 /**
  * @deprecated Usages of awsx.Cluster should be migrated to awsx.ecs.Cluster.
- * @internal
  */
 export interface ClusterNetworkArgs {
     /**


### PR DESCRIPTION
The type needs to be visible externally in order to be referenced during TypeScript compile-time by `CloudNetwork` in `shared.ts`

Fixes https://github.com/pulumi/pulumi-cloud/issues/778