### PR TITLE
Fix an issue where the subnet array is not unwrapped correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
 
+- Fix a bug where `subnetIds` was not being unwrapped correctly leading `Task.run` to fail for `@pulumi/cloud-aws`.
 ## 0.22.0 (Release Jan 27, 2021)
 
 - (Breaking) Replace `AWSLambdaFullAccess` with `LambdaFullAccess`, a more scoped down LambdaFullAccess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Fix a bug where `subnetIds` was not being unwrapped correctly leading `Task.run` to fail for `@pulumi/cloud-aws`.
+  [#785](https://github.com/pulumi/pulumi-cloud/pull/785)
 
 ## 0.22.0 (Release Jan 27, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Fix a bug where `subnetIds` was not being unwrapped correctly leading `Task.run` to fail for `@pulumi/cloud-aws`.
+
 ## 0.22.0 (Release Jan 27, 2021)
 
 - (Breaking) Replace `AWSLambdaFullAccess` with `LambdaFullAccess`, a more scoped down LambdaFullAccess

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -888,7 +888,7 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
         const clusterARN = this.cluster.ecsClusterARN;
         const taskDefinitionArn = this.taskDefinition.arn;
         const containerEnv = pulumi.all(container.environment || {});
-        const subnetIds = pulumi.output(network).subnetIds;
+        const subnetIds = pulumi.output(pulumi.output(network).subnetIds);
         const securityGroups =  cluster.securityGroupId!;
         const useFargate = config.useFargate;
         const assignPublicIp = pulumi.output(network).apply(n => useFargate && !n.usePrivateSubnets);


### PR DESCRIPTION
I ran into this issue when testing the `cloud-js-thumbnailer-machine-learning` example. Without this, the array is actually an array of `Input` types when we really want to have them be outputs so that the `.get()` correctly returns a plain array.