### PR TITLE
Include policies to match the default in @pulumi/aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
-
+- Fix a regression where `LambdaFullAccess` does not have enough permissions for most function scenarios.
+  Default to the same permissions for Lambda functions as `@pulumi/aws` along with `AmazonECSFullAccess`.
 ## 0.30.0 (Release April 19, 2021)
 
 - (Breaking) Update to Pulumi 3.0 packages

--- a/aws/shared.ts
+++ b/aws/shared.ts
@@ -90,6 +90,14 @@ export let runLambdaInVPC: boolean = config.usePrivateNetwork;
 // The IAM Role Policies to apply to compute for both Lambda and ECS
 const defaultComputePolicies = [
     aws.iam.ManagedPolicy.LambdaFullAccess,    // Provides full access to Lambda
+    aws.iam.ManagedPolicy.CloudWatchFullAccess,
+    aws.iam.ManagedPolicy.CloudWatchEventsFullAccess,
+    aws.iam.ManagedPolicy.AmazonS3FullAccess,
+    aws.iam.ManagedPolicy.AmazonDynamoDBFullAccess,
+    aws.iam.ManagedPolicy.AmazonSQSFullAccess,
+    aws.iam.ManagedPolicy.AmazonKinesisFullAccess,
+    aws.iam.ManagedPolicy.AmazonCognitoPowerUser,
+    aws.iam.ManagedPolicy.AWSXrayWriteOnlyAccess,
     aws.iam.ManagedPolicy.AmazonECSFullAccess, // Required for lambda compute to be able to run Tasks
 ];
 let computePolicies: aws.ARN[] = config.computeIAMRolePolicyARNs


### PR DESCRIPTION
Update the default policies to include the default set from `@pulumi/aws` along with the extra `aws.iam.ManagedPolicy.AmazonECSFullAccess`

It's worth noting that in the [previous change](https://github.com/pulumi/pulumi-cloud/pull/783) one of the thoughts was that we'd be willing to take a reduced scope of the newer Lambda full access managed policy as a breaking change. But, looking back, I think I didn't realize that the default compute policy was used for all functions and not just for tasks. Adding the full set of permissions here seems like the sane default given the functions use-case.

Fixes #791 