### PR TITLE
Allow use of non-pulumi cloud implementations

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -28,7 +28,13 @@ const provider = config.require("provider");
 
 // Load the implementation of @pulumi/cloud for the target provider.
 function loadFrameworkModule() {
-    const frameworkModule = `@pulumi/cloud-${provider}`;
+    // if the user has configured a fully qualified name for the provider then use 
+    // that as the module reference so that cloud implementations, maintained out
+    // of pulumi org, can be used, otherwise assume it's a @pulumi package.
+    const qualifiedModule = /^@/.test(provider);
+    const frameworkModule = qualifiedModule
+        ? provider
+        : `@pulumi/cloud-${provider}`;
     pulumi.log.debug(`Loading ${frameworkModule} for current environment.`);
     try {
         return require(frameworkModule);


### PR DESCRIPTION
This will avoid hacks like overriding require.resolve in user-land (which is prone to causing issues downstream)
 
Eg. https://github.com/getcoconut/coconut/blob/develop/packages/cli/src/lib/cmds/mock/pulumiProgram.ts#L6

FYI: This was just a quick edit in github ui. If this would be accepted as a change I'm happy to clone locally and ensure everything is passing/valid.