### PR TITLE
Allow inputs for CPU and Memory math for ECS Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Fix a bug to allow computing minimum task and memory size requirements as `Inputs` for `Service` in `cloud/aws`.
+
 ## 0.30.1 (Release May 24, 2021)
 
 - Fix a regression where `LambdaFullAccess` does not have enough permissions for most function scenarios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (Unreleased)
 
+- Fix a bug to allow computing minimum task and memory size requirements as `Inputs` for `Service` in `cloud/aws`.
 ## 0.30.1 (Release May 24, 2021)
 
 - Fix a regression where `LambdaFullAccess` does not have enough permissions for most function scenarios.

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -578,7 +578,7 @@ function taskMemoryAndCPUForContainers(defs: aws.ecs.ContainerDefinition[]) {
         }
 
         return cpu;
-    })
+    });
 
     // Return the computed task memory and CPU values
     return {

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -582,8 +582,8 @@ function taskMemoryAndCPUForContainers(defs: aws.ecs.ContainerDefinition[]) {
 
     // Return the computed task memory and CPU values
     return {
-        memory: `${taskMemory}`,
-        cpu: `${taskCPU}`,
+        memory: taskMemory.apply(m => m.toString()),
+        cpu: taskCPU.apply(c => c.toString()),
     };
 }
 


### PR DESCRIPTION
The build is currently broken as a result of changes (https://github.com/pulumi/pulumi-aws/pull/1054) to the most recent release of `pulumi-aws` which includes the option to pass in `Input` for container defintion. While technically a breaking change (because of issues like this), we did not expect anyone to do math on the type itself. Hopefully there are few cases like that in the wild. This PR updates the behavior to allow for the CPU and Memory values to be `Input` for computing the correct sizing.