### PR TITLE
Cleanup to address deprecations

### DIFF
--- a/aws/package.json
+++ b/aws/package.json
@@ -11,6 +11,11 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.378.0",
+        "@aws-sdk/client-ecs": "^3.378.0",
+        "@aws-sdk/client-s3": "^3.378.0",
+        "@aws-sdk/client-sns": "^3.378.0",
+        "@aws-sdk/lib-dynamodb": "^3.378.0",
         "@pulumi/pulumi": "^3.76.0",
         "@pulumi/aws": "^5.42.0",
         "@pulumi/awsx": "^0.40.0",

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -912,8 +912,8 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
 
         // tslint:disable-next-line:no-empty
         this.run = async function (options?: cloud.TaskRunOptions) {
-            const awssdk = await import("aws-sdk");
-            const ecs = new awssdk.ECS();
+            const ecssdk = await import("@aws-sdk/client-ecs");
+            const ecs = new ecssdk.ECS({});
 
             // Extract the envrionment values from the options
             const env: { name: string, value: string }[] = [];
@@ -941,7 +941,7 @@ export class Task extends pulumi.ComponentResource implements cloud.Task {
                         },
                     ],
                 },
-            }).promise();
+            });
 
             if (res.failures && res.failures.length > 0) {
                 throw new Error("Failed to start task:" + JSON.stringify(res.failures, null, ""));

--- a/aws/service.ts
+++ b/aws/service.ts
@@ -26,8 +26,8 @@ import { createNameWithStackInfo, getCluster, getComputeIAMRolePolicies,
 import * as utils from "./utils";
 
 interface ContainerPortLoadBalancer {
-    loadBalancer: aws.elasticloadbalancingv2.LoadBalancer;
-    targetGroup: aws.elasticloadbalancingv2.TargetGroup;
+    loadBalancer: aws.lb.LoadBalancer;
+    targetGroup: aws.lb.TargetGroup;
     protocol: cloud.ContainerProtocol;
 }
 
@@ -86,7 +86,7 @@ function createLoadBalancer(
             throw new Error(`Unrecognized Service protocol: ${portMapping.protocol}`);
     }
 
-    const loadBalancer = new aws.elasticloadbalancingv2.LoadBalancer(shortName, {
+    const loadBalancer = new aws.lb.LoadBalancer(shortName, {
         loadBalancerType: useAppLoadBalancer ? "application" : "network",
         subnets: pulumi.output(network).publicSubnetIds,
         internal: internal,
@@ -99,7 +99,7 @@ function createLoadBalancer(
     }, {parent: parent});
 
     // Create the target group for the new container/port pair.
-    const target = new aws.elasticloadbalancingv2.TargetGroup(shortName, {
+    const target = new aws.lb.TargetGroup(shortName, {
         port: portMapping.targetPort || portMapping.port,
         protocol: targetProtocol,
         vpcId: pulumi.output(network).vpcId,
@@ -111,7 +111,7 @@ function createLoadBalancer(
     }, { parent: parent });
 
     // Listen on the requested port on the LB and forward to the target.
-    const listener = new aws.elasticloadbalancingv2.Listener(longName, {
+    const listener = new aws.lb.Listener(longName, {
         loadBalancerArn: loadBalancer!.arn,
         protocol: protocol,
         certificateArn: useCertificateARN,
@@ -612,14 +612,14 @@ interface ExposedPorts {
 }
 
 interface ExposedPort {
-    host: aws.elasticloadbalancingv2.LoadBalancer;
+    host: aws.lb.LoadBalancer;
     hostPort: number;
     hostProtocol: cloud.ContainerProtocol;
 }
 
 // The AWS-specific Endpoint interface includes additional AWS implementation details for the exposed Endpoint.
 export interface Endpoint extends cloud.Endpoint {
-    loadBalancer: aws.elasticloadbalancingv2.LoadBalancer;
+    loadBalancer: aws.lb.LoadBalancer;
 }
 
 export type Endpoints = { [containerName: string]: { [port: number]: Endpoint } };

--- a/aws/shared.ts
+++ b/aws/shared.ts
@@ -91,13 +91,9 @@ export let runLambdaInVPC: boolean = config.usePrivateNetwork;
 const defaultComputePolicies = [
     aws.iam.ManagedPolicy.LambdaFullAccess,    // Provides full access to Lambda
     aws.iam.ManagedPolicy.CloudWatchFullAccess,
-    aws.iam.ManagedPolicy.CloudWatchEventsFullAccess,
     aws.iam.ManagedPolicy.AmazonS3FullAccess,
     aws.iam.ManagedPolicy.AmazonDynamoDBFullAccess,
-    aws.iam.ManagedPolicy.AmazonSQSFullAccess,
-    aws.iam.ManagedPolicy.AmazonKinesisFullAccess,
-    aws.iam.ManagedPolicy.AmazonCognitoPowerUser,
-    aws.iam.ManagedPolicy.AWSXrayWriteOnlyAccess,
+    aws.iam.ManagedPolicy.AmazonSNSFullAccess,
     aws.iam.ManagedPolicy.AmazonECSFullAccess, // Required for lambda compute to be able to run Tasks
 ];
 let computePolicies: aws.ARN[] = config.computeIAMRolePolicyARNs

--- a/aws/timer.ts
+++ b/aws/timer.ts
@@ -105,7 +105,7 @@ class Timer extends pulumi.ComponentResource {
 
         this.function = createFunction(
             name,
-            (ev: any, ctx: aws.serverless.Context, cb: (error: any, result: any) => void) => {
+            (ev: any, ctx: aws.lambda.Context, cb: (error: any, result: any) => void) => {
                 handler().then(() => {
                     cb(null, null);
                 }).catch((err: any) => {

--- a/aws/topic.ts
+++ b/aws/topic.ts
@@ -18,6 +18,8 @@ import * as pulumi from "@pulumi/pulumi";
 
 import { createCallbackFunction } from "./function";
 
+import * as snssdk from "@aws-sdk/client-sns";
+
 export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T> {
     private readonly name: string;
     public readonly topic: aws.sns.Topic;
@@ -36,11 +38,11 @@ export class Topic<T> extends pulumi.ComponentResource implements cloud.Topic<T>
         const topicId = this.topic.id;
 
         this.publish = async (item) => {
-            const snsconn = new aws.sdk.SNS();
-            const result = await snsconn.publish({
+            const sns = new snssdk.SNS({});
+            const result = await sns.publish({
                 Message: JSON.stringify(item),
                 TopicArn: topicId.get(),
-            }).promise();
+            });
         };
 
         this.registerOutputs({


### PR DESCRIPTION
* Remove use of deprecated `aws.severless` APIs
* Remove to AWS SDK v3
* Move off deprecated `elasticloadbalancingv2` module
* Limit default IAM roles
