### PR TITLE
Use Node.js 18 Lambda runtime by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## HEAD (Unreleased)
+## 0.40.1 (Release Jul 27, 2023)
+
+- Use Node.js 18.x Lambda runtime to ensure AWS SDK 3.0 is available
+
+## 0.40.0 (Release Jul 27, 2023)
 
 - Fix a bug to allow computing minimum task and memory size requirements as `Inputs` for `Service` in `cloud/aws`.
 - Update to use `@pulumi/aws` 5.x
@@ -11,6 +15,7 @@
 
 - Fix a regression where `LambdaFullAccess` does not have enough permissions for most function scenarios.
   Default to the same permissions for Lambda functions as `@pulumi/aws` along with `AmazonECSFullAccess`.
+
 ## 0.30.0 (Release April 19, 2021)
 
 - (Breaking) Update to Pulumi 3.0 packages

--- a/aws/function.ts
+++ b/aws/function.ts
@@ -51,6 +51,8 @@ export function createCallbackFunction(
     const args: aws.lambda.CallbackFunctionArgs<any, any> = {
         policies,
         vpcConfig,
+        // Require Node 18 to use AWS SDK 3.0
+        runtime: aws.lambda.Runtime.NodeJS18dX,
         memorySize: functionMemorySize,
         codePathOptions: {
             extraIncludePaths: functionIncludePaths,


### PR DESCRIPTION
This is necessary to ensure the AWS SDK 3.0 is available without needing to be pacakged into every lambda.