### PR TITLE
Normalize API route paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## Unreleased 
+
+- Allow trailing slash in API routes.
+
 ## 0.40.1 (Release Jul 27, 2023)
 
-- Use Node.js 18.x Lambda runtime to ensure AWS SDK 3.0 is available
+- Use Node.js 18.x Lambda runtime to ensure AWS SDK 3.0 is available.
 
 ## 0.40.0 (Release Jul 27, 2023)
 

--- a/aws/api.ts
+++ b/aws/api.ts
@@ -74,24 +74,28 @@ export class API implements cloud.API {
         this.customDomains = [];
     }
 
-    public static(path: string, localPath: string, options?: cloud.ServeStaticOptions) {
+    private cleanPath(path: string): string {
+        if (path.endsWith("/")) {
+            path = path.slice(0, -1);
+        }
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
+        return path;
+    }
+
+    public static(path: string, localPath: string, options?: cloud.ServeStaticOptions) {
+        path = this.cleanPath(path);
         this.staticRoutes.push({ path, localPath, options: options || {} });
     }
 
     public proxy(path: string, target: string | pulumi.Output<cloud.Endpoint>) {
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
+        path = this.cleanPath(path);
         this.proxyRoutes.push({ path, target });
     }
 
     public route(method: string, path: string, ...handlers: cloud.RouteHandler[]) {
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
+        path = this.cleanPath(path);
         this.routes.push({ method: method, path: path, handlers: handlers });
     }
 
@@ -146,7 +150,7 @@ export class HttpDeployment extends pulumi.ComponentResource implements cloud.Ht
     public /*out*/ readonly customDomains: aws.apigateway.DomainName[]; // AWS DomainName objects for custom domains.
 
     private static registerCustomDomains(parent: pulumi.Resource, apiName: string, api: aws.apigateway.RestApi,
-                                         domains: Domain[]): aws.apigateway.DomainName[] {
+        domains: Domain[]): aws.apigateway.DomainName[] {
 
         const awsDomains: aws.apigateway.DomainName[] = [];
         for (const domain of domains) {
@@ -174,13 +178,13 @@ export class HttpDeployment extends pulumi.ComponentResource implements cloud.Ht
                 };
             }
 
-            const awsDomain = new aws.apigateway.DomainName(apiNameAndHash, domainArgs, {parent});
+            const awsDomain = new aws.apigateway.DomainName(apiNameAndHash, domainArgs, { parent });
 
             const basePathMapping = new aws.apigateway.BasePathMapping(apiNameAndHash, {
                 restApi: api,
                 stageName: stageName,
                 domainName: awsDomain.domainName,
-            }, {parent});
+            }, { parent });
 
             awsDomains.push(awsDomain);
         }
@@ -189,9 +193,9 @@ export class HttpDeployment extends pulumi.ComponentResource implements cloud.Ht
     }
 
     constructor(name: string, staticRoutes: StaticRoute[], proxyRoutes: ProxyRoute[],
-                routes: Route[], customDomains: Domain[], opts?: pulumi.ResourceOptions) {
+        routes: Route[], customDomains: Domain[], opts?: pulumi.ResourceOptions) {
 
-        super("cloud:http:API", name, { }, opts);
+        super("cloud:http:API", name, {}, opts);
 
         this.staticRoutes = staticRoutes;
         this.proxyRoutes = proxyRoutes;
@@ -334,10 +338,10 @@ function convertHandlers(name: string, route: Route, opts: pulumi.ResourceOption
 
 const stageName = "stage";
 function apiGatewayToRequestResponse(
-        ev: awsx.apigateway.Request, body: Buffer, cb: (err: any, result: awsx.apigateway.Response) => void): [cloud.Request, cloud.Response] {
+    ev: awsx.apigateway.Request, body: Buffer, cb: (err: any, result: awsx.apigateway.Response) => void): [cloud.Request, cloud.Response] {
     const response = {
         statusCode: 200,
-        headers: <{[header: string]: string}>{},
+        headers: <{ [header: string]: string }>{},
         body: Buffer.from([]),
     };
     const headers: { [name: string]: string; } = {};

--- a/aws/api.ts
+++ b/aws/api.ts
@@ -150,7 +150,7 @@ export class HttpDeployment extends pulumi.ComponentResource implements cloud.Ht
     public /*out*/ readonly customDomains: aws.apigateway.DomainName[]; // AWS DomainName objects for custom domains.
 
     private static registerCustomDomains(parent: pulumi.Resource, apiName: string, api: aws.apigateway.RestApi,
-        domains: Domain[]): aws.apigateway.DomainName[] {
+                                         domains: Domain[]): aws.apigateway.DomainName[] {
 
         const awsDomains: aws.apigateway.DomainName[] = [];
         for (const domain of domains) {
@@ -193,7 +193,7 @@ export class HttpDeployment extends pulumi.ComponentResource implements cloud.Ht
     }
 
     constructor(name: string, staticRoutes: StaticRoute[], proxyRoutes: ProxyRoute[],
-        routes: Route[], customDomains: Domain[], opts?: pulumi.ResourceOptions) {
+                routes: Route[], customDomains: Domain[], opts?: pulumi.ResourceOptions) {
 
         super("cloud:http:API", name, {}, opts);
 


### PR DESCRIPTION
Remove trailing `/` from route before passing to API Gateway.

Fixes #726.