### PR TITLE
Re-add registry auth for NPM publish

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo


### PR DESCRIPTION
Required by setup-node, but only needed in the workflows that run `make publish_packages`.

Fixes #830 