### PR TITLE
Update Azure dependency version

### DIFF
--- a/azure/package.json
+++ b/azure/package.json
@@ -12,7 +12,7 @@
     "repository": "https://github.com/pulumi/pulumi-cloud",
     "dependencies": {
         "@pulumi/pulumi": "^3.76.0",
-        "@pulumi/azure": "^5.45.0",
+        "@pulumi/azure": "^5.60.0",
         "@pulumi/docker": "^3.0.0",
         "stream-buffers": "^3.0.2",
         "azure-storage": "^2.10.3",

--- a/azure/yarn.lock
+++ b/azure/yarn.lock
@@ -327,10 +327,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/azure@^5.45.0":
-  version "5.56.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/azure/-/azure-5.56.0.tgz#643b70d4c60954ebcbdf5383265537ea50c00bd6"
-  integrity sha512-wTLYnvvzhoZNft2Wo1BsvDO6HfXxl7JgKwyV9iRgUpZSSJsQe4TwnIPqmbITRliYQ9x2Xm/1gOUSTzzjXmW9EQ==
+"@pulumi/azure@^5.60.0":
+  version "5.60.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/azure/-/azure-5.60.0.tgz#6d468c9340c8f6edf3344abcc1de648f02d5ea5d"
+  integrity sha512-JebJ3C89tCPKJCUBwBqNTRfZY6/gdnZBgyNLz5MhQjw36i+nXDItbKKsvv9OxIirthNOxro6FRf58HpaqnT0jQ==
   dependencies:
     "@azure/eventgrid" "^4.6.0"
     "@azure/functions" "=1.2.2"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/stretchr/testify v1.6.1
 )
 
+replace sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
+
 require (
 	cloud.google.com/go v0.72.0 // indirect
 	cloud.google.com/go/logging v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,7 @@ github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:tNZjgbYncKL5HxvDULAr/mWDmFz4B7H8yrXEDlnoIiw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -958,4 +959,3 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=


### PR DESCRIPTION
Check if updating the `@pulumi/azure` dependency version avoids the current flakiness we are seeing in https://github.com/pulumi/pulumi-cloud/issues/832.  

Errors are all similar to this (but happen periodically but inconsistently across all of the Azure tests):

```
 updating auth settings for Function App: (Site Name "cloudexample6599904b" / Resource Group "p-it-fv-az914-8-topic-e8ce9f9b-global-bad633d2"): web.AppsClient#UpdateAuthSettings: Failure responding to request: StatusCode=500 -- Original Error: autorest/azure: Service returned an error. Status=500 Code="Unknown" Message="Unknown service error" Details=[{"Code":"InternalServerError","Details":[{"Message":null},{"Code":"InternalServerError"},{"ErrorEntity":{"Code":"InternalServerError","Message":null}}],"Innererror":null,"Message":null,"Target":null}]
```